### PR TITLE
Use correct naming in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ To fine-tune the behavior of the compiler, you can pass the following options:
 
 ```typescript
 compileQueries(queries, schemas, {
-  // Instead of returning an array of values for every statement (which allows for
-  // preventing SQL injections), all values are inlined directly into the SQL strings.
+  // Instead of returning an array of parameters for every statement (which allows for
+  // preventing SQL injections), all parameters are inlined directly into the SQL strings.
   // This option should only be used if the generated SQL will be manually verified.
-  inlineValues: true
+  inlineParams: true
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export const compileQueries = (
   queries: Array<Query>,
   schemas: Array<PublicSchema>,
   options?: {
-    inlineValues?: boolean;
+    inlineParams?: boolean;
   },
 ): Array<Statement> => {
   const schemaList = addSystemSchemas(schemas).map((schema) => {
@@ -38,7 +38,7 @@ export const compileQueries = (
     const result = compileQueryInput(
       query,
       schemaListWithPresets,
-      options?.inlineValues ? null : [],
+      options?.inlineParams ? null : [],
     );
 
     // Every query can only produce one main statement (which can return output), but

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -26,7 +26,7 @@ test('inline statement values', () => {
   ];
 
   const statements = compileQueries(queries, schemas, {
-    inlineValues: true,
+    inlineParams: true,
   });
 
   expect(statements).toEqual([


### PR DESCRIPTION
This change ensures that the `inlineValues` option documented in the readme is correctly named `inlineParams`, which is consistent with the `params` property property by the `Statement` type.