### PR TITLE
Stop patching JSON by default

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -99,7 +99,12 @@ export const composeAssociationModelSlug = (model: PublicModel, field: ModelFiel
  *
  * @returns The SQL column selector for the provided field.
  */
-const getFieldSelector = (field: ModelField, fieldPath: string,  instructionName: QueryInstructionType, rootTable?: string) => {
+const getFieldSelector = (
+  field: ModelField,
+  fieldPath: string,
+  instructionName: QueryInstructionType,
+  rootTable?: string,
+) => {
   const symbol = rootTable?.startsWith(RONIN_MODEL_SYMBOLS.FIELD)
     ? `${rootTable.replace(RONIN_MODEL_SYMBOLS.FIELD, '').slice(0, -1)}.`
     : '';
@@ -146,7 +151,12 @@ export const getFieldFromModel = (
     modelField = modelFields.find((field) => field.slug === fieldPath.split('.')[0]);
 
     if (modelField?.type === 'json') {
-      const fieldSelector = getFieldSelector(modelField, fieldPath, instructionName, rootTable);
+      const fieldSelector = getFieldSelector(
+        modelField,
+        fieldPath,
+        instructionName,
+        rootTable,
+      );
       return { field: modelField, fieldSelector };
     }
   }
@@ -162,7 +172,12 @@ export const getFieldFromModel = (
     });
   }
 
-  const fieldSelector = getFieldSelector(modelField, fieldPath, instructionName, rootTable);
+  const fieldSelector = getFieldSelector(
+    modelField,
+    fieldPath,
+    instructionName,
+    rootTable,
+  );
   return { field: modelField, fieldSelector };
 };
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -110,8 +110,8 @@ const getFieldSelector = (
     : '';
   const tablePrefix = symbol || (rootTable ? `"${rootTable}".` : '');
 
-  // If the field is of type JSON and a field is being selected (not updated), that means
-  // we should extract the nested property from the JSON field.
+  // If the field is of type JSON and the field is being selected in a read query, that
+  // means we should extract the nested property from the JSON field.
   if (field.type === 'json' && instructionName !== 'to') {
     const dotParts = fieldPath.split('.');
     const columnName = tablePrefix + dotParts.shift();

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -94,19 +94,20 @@ export const composeAssociationModelSlug = (model: PublicModel, field: ModelFiel
  * @param field - A field from a model.
  * @param fieldPath - The path of the field being addressed. Supports dot notation for
  * accessing nested fields.
+ * @param instructionName - The name of the query instruction that is being used.
  * @param rootTable - The name of a table, if it should be included in the SQL selector.
  *
  * @returns The SQL column selector for the provided field.
  */
-const getFieldSelector = (field: ModelField, fieldPath: string, rootTable?: string) => {
+const getFieldSelector = (field: ModelField, fieldPath: string,  instructionName: QueryInstructionType, rootTable?: string) => {
   const symbol = rootTable?.startsWith(RONIN_MODEL_SYMBOLS.FIELD)
     ? `${rootTable.replace(RONIN_MODEL_SYMBOLS.FIELD, '').slice(0, -1)}.`
     : '';
   const tablePrefix = symbol || (rootTable ? `"${rootTable}".` : '');
 
-  // If nested fields are allowed and the name of the field contains a period, that means
-  // we need to select a nested property from within a JSON field.
-  if (field.type === 'json') {
+  // If the field is of type JSON and a field is being selected (not updated), that means
+  // we should extract the nested property from the JSON field.
+  if (field.type === 'json' && instructionName !== 'to') {
     const dotParts = fieldPath.split('.');
     const columnName = tablePrefix + dotParts.shift();
     const jsonField = dotParts.join('.');
@@ -145,7 +146,7 @@ export const getFieldFromModel = (
     modelField = modelFields.find((field) => field.slug === fieldPath.split('.')[0]);
 
     if (modelField?.type === 'json') {
-      const fieldSelector = getFieldSelector(modelField, fieldPath, rootTable);
+      const fieldSelector = getFieldSelector(modelField, fieldPath, instructionName, rootTable);
       return { field: modelField, fieldSelector };
     }
   }
@@ -161,7 +162,7 @@ export const getFieldFromModel = (
     });
   }
 
-  const fieldSelector = getFieldSelector(modelField, fieldPath, rootTable);
+  const fieldSelector = getFieldSelector(modelField, fieldPath, instructionName, rootTable);
   return { field: modelField, fieldSelector };
 };
 

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -115,18 +115,6 @@ const composeFieldValues = (
 
     conditionSelector = `${options.customTable ? `"${options.customTable}".` : ''}"${modelField.slug}"`;
     conditionValue = `${targetTable}."${value.replace(toReplace, '')}"`;
-  }
-  // For columns containing JSON, special handling is required, because the properties
-  // inside a JSON structure cannot be updated directly using column selectors, and must
-  // instead be patched through a JSON function, since the properties are all stored
-  // inside a single TEXT column.
-  else if (modelField.type === 'json' && instructionName === 'to') {
-    conditionSelector = `"${modelField.slug}"`;
-
-    if (collectStatementValue) {
-      const preparedValue = prepareStatementValue(statementParams, value);
-      conditionValue = `IIF(${conditionSelector} IS NULL, ${preparedValue}, json_patch(${conditionSelector}, ${preparedValue}))`;
-    }
   } else if (collectStatementValue) {
     conditionValue = prepareStatementValue(statementParams, value);
   }

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -327,7 +327,7 @@ test('set single record to new json field with array', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "accounts" SET "emails" = IIF("emails" IS NULL, ?1, json_patch("emails", ?1)), "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
+      statement: `UPDATE "accounts" SET "emails" = ?1, "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
       params: [
         '["elaine@site.co","elaine@company.co"]',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -374,7 +374,7 @@ test('set single record to new json field with empty array', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "accounts" SET "emails" = IIF("emails" IS NULL, ?1, json_patch("emails", ?1)), "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
+      statement: `UPDATE "accounts" SET "emails" = ?1, "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
       params: ['[]', expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'elaine'],
       returning: true,
     },
@@ -420,7 +420,7 @@ test('set single record to new json field with object', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "accounts" SET "emails" = IIF("emails" IS NULL, ?1, json_patch("emails", ?1)), "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
+      statement: `UPDATE "accounts" SET "emails" = ?1, "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
       params: [
         '{"site":"elaine@site.co","hobby":"dancer@dancing.co"}',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -467,7 +467,7 @@ test('set single record to new json field with empty object', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "accounts" SET "emails" = IIF("emails" IS NULL, ?1, json_patch("emails", ?1)), "ronin.updatedAt" = ?2 WHERE ("handle" = ?3) RETURNING *`,
+      statement: `UPDATE \"accounts\" SET \"emails\" = ?1, \"ronin.updatedAt\" = ?2 WHERE (\"handle\" = ?3) RETURNING *`,
       params: ['{}', expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'elaine'],
       returning: true,
     },
@@ -622,7 +622,7 @@ test('set single record to new grouped json field', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "teams" SET "billing.invoiceRecipients" = IIF("billing.invoiceRecipients" IS NULL, ?1, json_patch("billing.invoiceRecipients", ?1)), "ronin.updatedAt" = ?2 WHERE ("id" = ?3) RETURNING *`,
+      statement: `UPDATE \"teams\" SET \"billing.invoiceRecipients\" = ?1, \"ronin.updatedAt\" = ?2 WHERE (\"id\" = ?3) RETURNING *`,
       params: [
         '["receipts@test.co"]',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -47,7 +47,7 @@ test('create new model', () => {
     },
     {
       statement:
-        'INSERT INTO "models" ("slug", "fields", "pluralSlug", "name", "pluralName", "idPrefix", "identifiers.name", "identifiers.slug", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, IIF("fields" IS NULL, ?2, json_patch("fields", ?2)), ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) RETURNING *',
+        'INSERT INTO "models" ("slug", "fields", "pluralSlug", "name", "pluralName", "idPrefix", "identifiers.name", "identifiers.slug", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) RETURNING *',
       params: [
         'account',
         JSON.stringify([...SYSTEM_FIELDS, ...fields]),
@@ -636,7 +636,7 @@ test('create new index', () => {
     },
     {
       statement:
-        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("fields" IS NULL, ?3, json_patch("fields", ?3)), ?4, ?5, ?6) RETURNING *',
+        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6) RETURNING *',
       params: [
         'index_slug',
         'account',
@@ -695,7 +695,7 @@ test('create new index with filter', () => {
     },
     {
       statement:
-        'INSERT INTO "indexes" ("slug", "model", "fields", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("fields" IS NULL, ?3, json_patch("fields", ?3)), IIF("filter" IS NULL, ?4, json_patch("filter", ?4)), ?5, ?6, ?7) RETURNING *',
+        'INSERT INTO "indexes" ("slug", "model", "fields", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7) RETURNING *',
       params: [
         'index_slug',
         'account',
@@ -756,7 +756,7 @@ test('create new index with field expressions', () => {
     },
     {
       statement:
-        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("fields" IS NULL, ?3, json_patch("fields", ?3)), ?4, ?5, ?6) RETURNING *',
+        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6) RETURNING *',
       params: [
         'index_slug',
         'account',
@@ -809,7 +809,7 @@ test('create new index with ordered and collated fields', () => {
     },
     {
       statement:
-        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("fields" IS NULL, ?3, json_patch("fields", ?3)), ?4, ?5, ?6) RETURNING *',
+        'INSERT INTO "indexes" ("slug", "model", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6) RETURNING *',
       params: [
         'index_slug',
         'account',
@@ -861,7 +861,7 @@ test('create new unique index', () => {
     },
     {
       statement:
-        'INSERT INTO "indexes" ("slug", "model", "fields", "unique", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("fields" IS NULL, ?3, json_patch("fields", ?3)), ?4, ?5, ?6, ?7) RETURNING *',
+        'INSERT INTO "indexes" ("slug", "model", "fields", "unique", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7) RETURNING *',
       params: [
         'index_slug',
         'account',
@@ -966,7 +966,7 @@ test('create new trigger for creating records', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), ?6, ?7, ?8) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
       params: [
         'trigger_slug',
         'account',
@@ -1044,7 +1044,7 @@ test('create new trigger for creating records with targeted fields', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), IIF("fields" IS NULL, ?6, json_patch("fields", ?6)), ?7, ?8, ?9) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8, ?9) RETURNING *',
       params: [
         'trigger_slug',
         'account',
@@ -1132,7 +1132,7 @@ test('create new trigger for creating records with multiple effects', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), ?6, ?7, ?8) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
       params: [
         'trigger_slug',
         'account',
@@ -1212,7 +1212,7 @@ test('create new per-record trigger for creating records', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), ?6, ?7, ?8) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
       params: [
         'trigger_slug',
         'team',
@@ -1284,7 +1284,7 @@ test('create new per-record trigger for deleting records', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), ?6, ?7, ?8) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
       params: [
         'trigger_slug',
         'team',
@@ -1373,7 +1373,7 @@ test('create new per-record trigger with filters for creating records', () => {
     },
     {
       statement:
-        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, IIF("effects" IS NULL, ?5, json_patch("effects", ?5)), IIF("filter" IS NULL, ?6, json_patch("filter", ?6)), ?7, ?8, ?9) RETURNING *',
+        'INSERT INTO "triggers" ("slug", "model", "when", "action", "effects", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6, ?7, ?8, ?9) RETURNING *',
       params: [
         'trigger_slug',
         'team',
@@ -1461,7 +1461,7 @@ test('create new preset', () => {
   expect(statements).toEqual([
     {
       statement:
-        'INSERT INTO "presets" ("slug", "model", "instructions", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), IIF("instructions" IS NULL, ?3, json_patch("instructions", ?3)), ?4, ?5, ?6) RETURNING *',
+        'INSERT INTO "presets" ("slug", "model", "instructions", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "models" WHERE ("slug" = ?2) LIMIT 1), ?3, ?4, ?5, ?6) RETURNING *',
       params: [
         'company_employees',
         'account',


### PR DESCRIPTION
In preparation for support of expressions in column values (which is landing shortly and will support [SQL functions](https://www.sqlite.org/lang_corefunc.html)), we need to stop patching the contents of JSON fields by default.

In other words:

We need to stop invoking `json_patch` by default, in order to allow for a coherent, easy-to-understand default behavior when interacting with JSON fields. When selecting nested JSON fields, we will continue to run `json_extract`, but when writing them, since we cannot predict the best transformation behavior accurately (adding properties, removing them, overwriting them, or deeply patching them), we need to default to overwriting the field value entirely.

If someone wants to run `json_patch`, `json_remove`, or similar functions, they will be able to do so using support for expressions, which is landing after the current PR. 