### PR TITLE
Added support for expressions in `orderedBy`

### DIFF
--- a/src/instructions/before-after.ts
+++ b/src/instructions/before-after.ts
@@ -77,7 +77,7 @@ export const handleBeforeOrAfter = (
       return 'NULL';
     }
 
-    const { field } = getFieldFromModel(model, key, 'orderedBy');
+    const { field } = getFieldFromModel(model, key as string, 'orderedBy');
 
     if (field.type === 'boolean') {
       return prepareStatementValue(statementParams, value === 'true');
@@ -122,7 +122,7 @@ export const handleBeforeOrAfter = (
       const key = keys[j];
       const value = values[j];
 
-      let { field, fieldSelector } = getFieldFromModel(model, key, 'orderedBy');
+      let { field, fieldSelector } = getFieldFromModel(model, key as string, 'orderedBy');
 
       // If we're at the current field, add the comparison to the condition.
       if (j === i) {
@@ -145,7 +145,7 @@ export const handleBeforeOrAfter = (
         if (
           value !== 'NULL' &&
           operator === '<' &&
-          !['ronin.createdAt', 'ronin.updatedAt'].includes(key)
+          !['ronin.createdAt', 'ronin.updatedAt'].includes(key as string)
         ) {
           fieldSelector = `IFNULL(${fieldSelector}, -1e999)`;
         }

--- a/src/instructions/ordered-by.ts
+++ b/src/instructions/ordered-by.ts
@@ -1,7 +1,7 @@
 import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
 import { getFieldFromModel } from '@/src/utils/model';
-import { getSymbol } from '@/src/utils/statement';
+import { getSymbol, parseFieldExpression } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `orderedBy` query instruction, which allows for
@@ -29,9 +29,11 @@ export const handleOrderedBy = (
     }
 
     const symbol = getSymbol(item.value);
+    const instructionName =
+      item.order === 'ASC' ? 'orderedBy.ascending' : 'orderedBy.descending';
 
     if (symbol?.type === 'expression') {
-      statement += `${symbol.value} ${item.order}`;
+      statement += `(${parseFieldExpression(model, instructionName, symbol.value)}) ${item.order}`;
       continue;
     }
 
@@ -39,7 +41,7 @@ export const handleOrderedBy = (
     const { field: modelField, fieldSelector } = getFieldFromModel(
       model,
       item.value as string,
-      item.order === 'ASC' ? 'orderedBy.ascending' : 'orderedBy.descending',
+      instructionName,
     );
 
     const caseInsensitiveStatement =

--- a/src/instructions/ordered-by.ts
+++ b/src/instructions/ordered-by.ts
@@ -1,6 +1,7 @@
 import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
 import { getFieldFromModel } from '@/src/utils/model';
+import { getSymbol } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `orderedBy` query instruction, which allows for
@@ -17,44 +18,34 @@ export const handleOrderedBy = (
 ): string => {
   let statement = '';
 
-  for (const field of instruction!.ascending || []) {
-    // Check whether the field exists.
-    const { field: modelField, fieldSelector } = getFieldFromModel(
-      model,
-      field,
-      'orderedBy.ascending',
-    );
+  const items = [
+    ...(instruction!.ascending || []).map((value) => ({ value, order: 'ASC' })),
+    ...(instruction!.descending || []).map((value) => ({ value, order: 'DESC' })),
+  ];
 
+  for (const item of items) {
     if (statement.length > 0) {
       statement += ', ';
     }
 
-    const caseInsensitiveStatement =
-      modelField.type === 'string' ? ' COLLATE NOCASE' : '';
+    const symbol = getSymbol(item.value);
 
-    statement += `${fieldSelector}${caseInsensitiveStatement} ASC`;
-  }
+    if (symbol?.type === 'expression') {
+      statement += `${symbol.value} ${item.order}`;
+      continue;
+    }
 
-  // If multiple records are being retrieved, the `orderedBy.descending` property is
-  // never undefined, because it is automatically added outside the `handleOrderedBy`
-  // function. If a single record is being retrieved, however, it will be undefined, so
-  // we need the empty array fallback.
-  for (const field of instruction!.descending || []) {
     // Check whether the field exists.
     const { field: modelField, fieldSelector } = getFieldFromModel(
       model,
-      field,
-      'orderedBy.descending',
+      item.value as string,
+      item.order === 'ASC' ? 'orderedBy.ascending' : 'orderedBy.descending',
     );
-
-    if (statement.length > 0) {
-      statement += ', ';
-    }
 
     const caseInsensitiveStatement =
       modelField.type === 'string' ? ' COLLATE NOCASE' : '';
 
-    statement += `${fieldSelector}${caseInsensitiveStatement} DESC`;
+    statement += `${fieldSelector}${caseInsensitiveStatement} ${item.order}`;
   }
 
   return `ORDER BY ${statement}`;

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -19,7 +19,6 @@ import type {
   WithInstruction,
 } from '@/src/types/query';
 import {
-  RONIN_MODEL_FIELD_REGEX,
   RONIN_MODEL_SYMBOLS,
   RoninError,
   convertToCamelCase,
@@ -28,6 +27,7 @@ import {
   type splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
+import { parseFieldExpression } from '@/src/utils/statement';
 import title from 'title';
 
 /**
@@ -814,10 +814,7 @@ export const addModelQueries = (
         // insert them into the expression, after which the expression can be used in the
         // SQL statement.
         else if ('expression' in field) {
-          fieldSelector = field.expression.replace(RONIN_MODEL_FIELD_REGEX, (match) => {
-            const fieldSlug = match.replace(RONIN_MODEL_SYMBOLS.FIELD, '');
-            return getFieldFromModel(model, fieldSlug, 'to').fieldSelector;
-          });
+          fieldSelector = parseFieldExpression(model, 'to', field.expression, model);
         }
 
         if (field.collation) fieldSelector += ` COLLATE ${field.collation}`;

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -1,3 +1,4 @@
+import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 import { z } from 'zod';
 
 // Query Types.
@@ -12,6 +13,11 @@ export const FieldValue = z.union(
   },
 );
 export const FieldSelector = z.record(FieldValue);
+
+// Expression
+export const ExpressionSchema = z.object({
+  [RONIN_MODEL_SYMBOLS.EXPRESSION]: z.string(),
+});
 
 // With Instructions.
 export const WithInstructionRefinementTypes = z.enum([
@@ -115,25 +121,31 @@ export const OrderedByInstructionSchema = z
   .object({
     ascending: z
       .array(
-        z.string({
-          invalid_type_error:
-            'The `orderedBy.ascending` instruction must be an array of strings.',
-        }),
+        z.union([
+          z.string({
+            invalid_type_error:
+              'The `orderedBy.ascending` instruction must be an array of field slugs or expressions.',
+          }),
+          ExpressionSchema,
+        ]),
         {
           invalid_type_error:
-            'The `orderedBy.ascending` instruction must be an array of strings.',
+            'The `orderedBy.ascending` instruction must be an array of field slugs or expressions.',
         },
       )
       .optional(),
     descending: z
       .array(
-        z.string({
-          invalid_type_error:
-            'The `orderedBy.descending` instruction must be an array of strings.',
-        }),
+        z.union([
+          z.string({
+            invalid_type_error:
+              'The `orderedBy.descending` instruction must be an array of field slugs or expressions.',
+          }),
+          ExpressionSchema,
+        ]),
         {
           invalid_type_error:
-            'The `orderedBy.descending` instruction must be an array of strings.',
+            'The `orderedBy.descending` instruction must be an array of field slugs or expressions.',
         },
       )
       .optional(),

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -47,7 +47,7 @@ test('get multiple records ordered by expression', () => {
           orderedBy: {
             ascending: [
               {
-                [RONIN_MODEL_SYMBOLS.EXPRESSION]: 'RANDOM()',
+                [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD}firstName || ' ' || ${RONIN_MODEL_SYMBOLS.FIELD}lastName`,
               },
             ],
           },
@@ -61,7 +61,11 @@ test('get multiple records ordered by expression', () => {
       slug: 'account',
       fields: [
         {
-          slug: 'handle',
+          slug: 'firstName',
+          type: 'string',
+        },
+        {
+          slug: 'lastName',
           type: 'string',
         },
       ],
@@ -72,7 +76,7 @@ test('get multiple records ordered by expression', () => {
 
   expect(statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY RANDOM() ASC`,
+      statement: `SELECT * FROM "accounts" ORDER BY ("firstName" || ' ' || "lastName") ASC`,
       params: [],
       returning: true,
     },

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { type Model, compileQueries } from '@/src/index';
 import type { Query } from '@/src/types/query';
+import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 
 test('get multiple records ordered by field', () => {
   const queries: Array<Query> = [
@@ -32,6 +33,46 @@ test('get multiple records ordered by field', () => {
   expect(statements).toEqual([
     {
       statement: `SELECT * FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC`,
+      params: [],
+      returning: true,
+    },
+  ]);
+});
+
+test('get multiple records ordered by expression', () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        accounts: {
+          orderedBy: {
+            ascending: [
+              {
+                [RONIN_MODEL_SYMBOLS.EXPRESSION]: 'RANDOM()',
+              },
+            ],
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+      fields: [
+        {
+          slug: 'handle',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const statements = compileQueries(queries, models);
+
+  expect(statements).toEqual([
+    {
+      statement: `SELECT * FROM "accounts" ORDER BY RANDOM() ASC`,
       params: [],
       returning: true,
     },


### PR DESCRIPTION
This is a follow-up change to https://github.com/ronin-co/compiler/pull/29 and makes it possible to use field expressions in the `orderedBy` instruction.