### PR TITLE
Renamed "reference" field type to "link"

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -128,15 +128,15 @@ export const handleTo = (
   // Assign default field values to the provided instruction.
   Object.assign(toInstruction, defaultFields);
 
-  // For reference fields of the cardinality "many", we need to compose separate
-  // queries for managing the records in the associative model, which is the model
-  // that is used to establish the relationship between two other models, as those two
-  // do not share a direct reference.
+  // For link fields with the cardinality "many", we need to compose separate queries for
+  // managing the records in the associative model, which is the model that is used to
+  // establish the relationship between two other models, as those two do not share a
+  // direct link.
   for (const fieldSlug in toInstruction) {
     const fieldValue = toInstruction[fieldSlug];
     const fieldDetails = getFieldFromModel(model, fieldSlug, 'to');
 
-    if (fieldDetails.field.type === 'reference' && fieldDetails.field.kind === 'many') {
+    if (fieldDetails.field.type === 'link' && fieldDetails.field.kind === 'many') {
       // Remove the field from the `to` instruction as it will be handled using
       // separate queries.
       delete toInstruction[fieldSlug];

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -21,7 +21,7 @@ export type ModelFieldReferenceAction =
   | 'NO ACTION';
 
 export type ModelFieldReference = ModelFieldBasics & {
-  type: 'reference';
+  type: 'link';
 
   // Make the `slug` required.
   target: Omit<Partial<Model>, 'slug'> & Pick<Model, 'slug'>;
@@ -120,8 +120,8 @@ export interface Model {
 
   /**
    * If the model is used to associate two models with each other (in the case of
-   * many-cardinality reference fields), this property should contain the field to which
-   * the associative model should be mounted.
+   * many-cardinality link fields), this property should contain the field slug to which
+   * the associative model should be mounted on the source model.
    */
   associationSlug?: string;
 

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -220,7 +220,7 @@ export const composeConditions = (
   // a field is being asserted, so we first have to check whether that field exists and
   // then check its type. Based on that, we then know how to treat the value of the field.
   //
-  // Specifically, if the field is of the type "reference" or "json", we have to treat any
+  // Specifically, if the field is of the type "link" or "json", we have to treat any
   // potential object value in a special way, instead of just iterating over the nested
   // fields and trying to assert the column for each one.
   if (options.fieldSlug) {
@@ -242,7 +242,7 @@ export const composeConditions = (
       );
     }
 
-    if (modelField.type === 'reference' && isNested) {
+    if (modelField.type === 'link' && isNested) {
       // `value` is asserted to be an object using `isObject` above, so we can safely
       // cast it here. The type is not being inferred automatically.
       const keys = Object.keys(value as object);
@@ -251,9 +251,9 @@ export const composeConditions = (
       let recordTarget: WithValue | Record<typeof RONIN_MODEL_SYMBOLS.QUERY, Query>;
 
       // If only a single key is present, and it's "id", then we can simplify the query a
-      // bit in favor of performance, because the stored value of a reference field in
-      // SQLite is always the ID of the related record. That means we don't need to join
-      // the destination table, and we can just perform a string assertion.
+      // bit in favor of performance, because the stored value of a link field in SQLite
+      // is always the ID of the linked record. That means we don't need to join the
+      // destination table, and we can just perform a string assertion.
       if (keys.length === 1 && keys[0] === 'id') {
         // This can be either a string or an object with conditions such as `being`.
         recordTarget = values[0];

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -27,12 +27,12 @@ test('get single record for preset', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
         {
@@ -46,7 +46,7 @@ test('get single record for preset', () => {
       fields: [
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
       ],
@@ -101,12 +101,12 @@ test('get single record for preset containing field with condition', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
         {
@@ -120,7 +120,7 @@ test('get single record for preset containing field with condition', () => {
       fields: [
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
       ],
@@ -186,12 +186,12 @@ test('get single record for preset containing field without condition', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
         {
@@ -205,7 +205,7 @@ test('get single record for preset containing field without condition', () => {
       fields: [
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
       ],
@@ -270,12 +270,12 @@ test('get single record for preset on existing object instruction', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
       ],
@@ -328,12 +328,12 @@ test('get single record for preset on existing array instruction', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
         {
           slug: 'space',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'space' },
         },
       ],
@@ -379,7 +379,7 @@ test('get single record including parent record (many-to-one)', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
           kind: 'one',
         },
@@ -415,7 +415,7 @@ test('get single record including child records (one-to-many, defined manually)'
       fields: [
         {
           slug: 'comments',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'comment' },
           kind: 'many',
         },
@@ -457,7 +457,7 @@ test('get single record including child records (one-to-many, defined automatica
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -93,7 +93,7 @@ test('set single record to new string field with expression referencing fields',
   ]);
 });
 
-test('set single record to new one-cardinality reference field', () => {
+test('set single record to new one-cardinality link field', () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -126,7 +126,7 @@ test('set single record to new one-cardinality reference field', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],
@@ -148,7 +148,7 @@ test('set single record to new one-cardinality reference field', () => {
   ]);
 });
 
-test('set single record to new many-cardinality reference field', () => {
+test('set single record to new many-cardinality link field', () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -170,7 +170,7 @@ test('set single record to new many-cardinality reference field', () => {
       fields: [
         {
           slug: 'comments',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'comment' },
           kind: 'many',
         },
@@ -214,7 +214,7 @@ test('set single record to new many-cardinality reference field', () => {
   ]);
 });
 
-test('set single record to new many-cardinality reference field (add)', () => {
+test('set single record to new many-cardinality link field (add)', () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -238,7 +238,7 @@ test('set single record to new many-cardinality reference field (add)', () => {
       fields: [
         {
           slug: 'comments',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'comment' },
           kind: 'many',
         },
@@ -278,7 +278,7 @@ test('set single record to new many-cardinality reference field (add)', () => {
   ]);
 });
 
-test('set single record to new many-cardinality reference field (delete)', () => {
+test('set single record to new many-cardinality link field (delete)', () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -302,7 +302,7 @@ test('set single record to new many-cardinality reference field (delete)', () =>
       fields: [
         {
           slug: 'comments',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'comment' },
           kind: 'many',
         },
@@ -482,7 +482,7 @@ test('set single record to new grouped string field', () => {
   ]);
 });
 
-test('set single record to new grouped reference field', () => {
+test('set single record to new grouped link field', () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -521,7 +521,7 @@ test('set single record to new grouped reference field', () => {
         },
         {
           slug: 'billing.manager',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -541,7 +541,7 @@ test('get single record with multiple fields being value', () => {
   ]);
 });
 
-test('get single record with reference field', () => {
+test('get single record with link field', () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -571,7 +571,7 @@ test('get single record with reference field', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],
@@ -590,7 +590,7 @@ test('get single record with reference field', () => {
   ]);
 });
 
-test('get single record with reference field and id', () => {
+test('get single record with link field and id', () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -614,7 +614,7 @@ test('get single record with reference field and id', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],
@@ -632,7 +632,7 @@ test('get single record with reference field and id', () => {
   ]);
 });
 
-test('get single record with reference field and id with condition', () => {
+test('get single record with link field and id with condition', () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -658,7 +658,7 @@ test('get single record with reference field and id with condition', () => {
       fields: [
         {
           slug: 'account',
-          type: 'reference',
+          type: 'link',
           target: { slug: 'account' },
         },
       ],

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -373,7 +373,7 @@ test('create new field', () => {
   ]);
 });
 
-test('create new reference field', () => {
+test('create new link field', () => {
   const queries: Array<Query> = [
     {
       create: {
@@ -381,7 +381,7 @@ test('create new reference field', () => {
           to: {
             model: { slug: 'member' },
             slug: 'account',
-            type: 'reference',
+            type: 'link',
             target: { slug: 'account' },
           },
         },
@@ -412,7 +412,7 @@ test('create new reference field', () => {
       params: [
         'member',
         'account',
-        'reference',
+        'link',
         'account',
         expect.stringMatching(RECORD_ID_REGEX),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -423,7 +423,7 @@ test('create new reference field', () => {
   ]);
 });
 
-test('create new reference field with actions', () => {
+test('create new link field with actions', () => {
   const queries: Array<Query> = [
     {
       create: {
@@ -431,7 +431,7 @@ test('create new reference field with actions', () => {
           to: {
             model: { slug: 'member' },
             slug: 'account',
-            type: 'reference',
+            type: 'link',
             target: { slug: 'account' },
             actions: {
               onDelete: 'CASCADE',
@@ -465,7 +465,7 @@ test('create new reference field with actions', () => {
       params: [
         'member',
         'account',
-        'reference',
+        'link',
         'account',
         'CASCADE',
         expect.stringMatching(RECORD_ID_REGEX),


### PR DESCRIPTION
This change applies a shorter term for fields of type "reference": The type will now be called "link".

The term is defined as:

> a relationship between two things or situations, especially where one affects the other

...which is suitable for our current needs.

Most importantly, however, the term is more concise, while still providing the same meaning as "reference".