### PR TITLE
Added `check` attribute for fields

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,4 +1,9 @@
-import type { GetInstructions, Query, WithInstruction } from '@/src/types/query';
+import type {
+  Expression,
+  GetInstructions,
+  Query,
+  WithInstruction,
+} from '@/src/types/query';
 
 type ModelFieldBasics = {
   name?: string;
@@ -7,7 +12,7 @@ type ModelFieldBasics = {
   unique?: boolean;
   required?: boolean;
   defaultValue?: unknown;
-  check?: string;
+  check?: Expression;
 };
 
 type ModelFieldNormal = ModelFieldBasics & {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -126,17 +126,19 @@ export interface Model {
    */
   associationSlug?: string;
 
+  // Fields are not optional for internal models, because internal models within the
+  // compiler always at least contain the default fields. For models that are passed into
+  // the compiler from the outside, the fields are optional, because the compiler will
+  // add the default fields automatically, and those are enough to create a model.
   fields: Array<ModelField>;
   indexes?: Array<ModelIndex>;
   triggers?: Array<ModelTrigger>;
   presets?: Array<ModelPreset>;
 }
 
-type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends object ? RecursivePartial<T[P]> : T[P];
+export type PartialModel = Omit<Partial<Model>, 'identifiers'> & {
+  identifiers?: Partial<Model['identifiers']>;
 };
-
-export type PartialModel = RecursivePartial<Model>;
 
 // In models provided to the compiler, all settings are optional, except for the `slug`,
 // which is the required bare minimum.

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -7,6 +7,7 @@ type ModelFieldBasics = {
   unique?: boolean;
   required?: boolean;
   defaultValue?: unknown;
+  check?: string;
 };
 
 type ModelFieldNormal = ModelFieldBasics & {
@@ -125,7 +126,7 @@ export interface Model {
    */
   associationSlug?: string;
 
-  fields?: Array<ModelField>;
+  fields: Array<ModelField>;
   indexes?: Array<ModelIndex>;
   triggers?: Array<ModelTrigger>;
   presets?: Array<ModelPreset>;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -6,6 +6,7 @@ import type {
   CreateQuerySchema,
   DropInstructionsSchema,
   DropQuerySchema,
+  ExpressionSchema,
   GetInstructionsSchema,
   GetQuerySchema,
   IncludingInstructionSchema,
@@ -50,6 +51,9 @@ export type IncludingInstruction = z.infer<typeof IncludingInstructionSchema>;
 
 // Ordering Instructions.
 export type OrderedByInstrucion = z.infer<typeof OrderedByInstructionSchema>;
+
+// Expressions.
+export type Expression = z.infer<typeof ExpressionSchema>;
 
 /**
  * Union of the instructions for all query types. It requires or disallows fields

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -27,7 +27,7 @@ import {
   type splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
-import { parseFieldExpression } from '@/src/utils/statement';
+import { getSymbol, parseFieldExpression } from '@/src/utils/statement';
 import title from 'title';
 
 /**
@@ -679,7 +679,8 @@ const getFieldStatement = (model: Model, field: ModelField): string | null => {
     statement += ` DEFAULT ${field.defaultValue}`;
 
   if (typeof field.check !== 'undefined') {
-    statement += ` CHECK (${parseFieldExpression(model, 'to', field.check)})`;
+    const symbol = getSymbol(field.check);
+    statement += ` CHECK (${parseFieldExpression(model, 'to', symbol?.value as string)})`;
   }
 
   if (field.type === 'link') {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -19,6 +19,9 @@ test('create new model', () => {
     {
       slug: 'email',
       type: 'string',
+      required: true,
+      unique: true,
+      check: `length(${RONIN_MODEL_SYMBOLS.FIELD}handle) >= 3`,
     },
   ];
 
@@ -42,7 +45,7 @@ test('create new model', () => {
   expect(statements).toEqual([
     {
       statement:
-        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT)',
+        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL CHECK (length("handle") >= 3))',
       params: [],
     },
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -21,7 +21,9 @@ test('create new model', () => {
       type: 'string',
       required: true,
       unique: true,
-      check: `length(${RONIN_MODEL_SYMBOLS.FIELD}handle) >= 3`,
+      check: {
+        [RONIN_MODEL_SYMBOLS.EXPRESSION]: `length(${RONIN_MODEL_SYMBOLS.FIELD}handle) >= 3`,
+      },
     },
   ];
 


### PR DESCRIPTION
This change makes it possible to define a `check` attribute when adding fields to a model.

The attribute can contain an expression that determines whether the value of the field is valid, or not.

This is based on the changes added in https://github.com/ronin-co/compiler/pull/29.