### PR TITLE
Added more field constraints

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -5,6 +5,8 @@ import type {
   WithInstruction,
 } from '@/src/types/query';
 
+type ModelFieldCollation = 'BINARY' | 'NOCASE' | 'RTRIM';
+
 type ModelFieldBasics = {
   name?: string;
   slug: string;
@@ -13,6 +15,7 @@ type ModelFieldBasics = {
   required?: boolean;
   defaultValue?: unknown;
   check?: Expression;
+  collation?: ModelFieldCollation;
 };
 
 type ModelFieldNormal = ModelFieldBasics & {
@@ -43,7 +46,7 @@ export type ModelField = ModelFieldNormal | ModelFieldReference;
 
 export type ModelIndexField = {
   /** The collating sequence used for text placed inside the field. */
-  collation?: 'BINARY' | 'NOCASE' | 'RTRIM';
+  collation?: ModelFieldCollation;
   /** How the records in the index should be ordered. */
   order?: 'ASC' | 'DESC';
 } & (

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -8,14 +8,35 @@ import type {
 type ModelFieldCollation = 'BINARY' | 'NOCASE' | 'RTRIM';
 
 type ModelFieldBasics = {
+  /** The label that should be used when displaying the field on the RONIN dashboard. */
   name?: string;
+  /** Allows for addressing the field programmatically. */
   slug: string;
+  /** How the field should be displayed visually on the RONIN dashboard. */
   displayAs?: string;
+  /**
+   * If set, only one record of the same model will be allowed to exist with a given
+   * value for the field.
+   */
   unique?: boolean;
+  /**
+   * Whether a value must be provided for the field. If this attribute is set and no
+   * value is provided, an error will be thrown.
+   */
   required?: boolean;
+  /**
+   * The value that should be inserted into the field in the case that no value was
+   * explicitly provided for it when a record is created.
+   */
   defaultValue?: unknown;
+  /** An expression that gets evaluated every time a value is provided for the field. */
   check?: Expression;
+  /** The collation sequence to use for the field value. */
   collation?: ModelFieldCollation;
+  /**
+   * If the field is of type `number`, setting this attribute will autmatically increment
+   * the value of the field with every new record that gets inserted.
+   */
   increment?: boolean;
 };
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -40,10 +40,13 @@ type ModelFieldBasics = {
   };
   /** An expression that gets evaluated every time a value is provided for the field. */
   check?: Expression;
-  /** The collation sequence to use for the field value. */
+  /**
+   * If the field is of type `string`, setting this attribute defines the collation
+   * sequence to use for the field value.
+   */
   collation?: ModelFieldCollation;
   /**
-   * If the field is of type `number`, setting this attribute will autmatically increment
+   * If the field is of type `number`, setting this attribute will automatically increment
    * the value of the field with every new record that gets inserted.
    */
   increment?: boolean;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -16,6 +16,7 @@ type ModelFieldBasics = {
   defaultValue?: unknown;
   check?: Expression;
   collation?: ModelFieldCollation;
+  increment?: boolean;
 };
 
 type ModelFieldNormal = ModelFieldBasics & {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -29,6 +29,15 @@ type ModelFieldBasics = {
    * explicitly provided for it when a record is created.
    */
   defaultValue?: unknown;
+  /**
+   * An expression that should be evaluated to form the value of the field. The
+   * expression can either be VIRTUAL (evaluated whenever a record is read) or STORED
+   * (evaluated whenever a record is created or updated).
+   */
+  computedAs?: {
+    kind: 'VIRTUAL' | 'STORED';
+    value: Expression;
+  };
   /** An expression that gets evaluated every time a value is provided for the field. */
   check?: Expression;
   /** The collation sequence to use for the field value. */

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -685,6 +685,12 @@ const getFieldStatement = (model: Model, field: ModelField): string | null => {
     statement += ` CHECK (${parseFieldExpression(model, 'to', symbol?.value as string)})`;
   }
 
+  if (typeof field.computedAs !== 'undefined') {
+    const { kind, value } = field.computedAs;
+    const symbol = getSymbol(value);
+    statement += ` GENERATED ALWAYS AS (${parseFieldExpression(model, 'to', symbol?.value as string)}) ${kind}`;
+  }
+
   if (field.type === 'link') {
     const actions = field.actions || {};
     const targetTable = convertToSnakeCase(pluralize(field.target.slug));

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -677,6 +677,7 @@ const getFieldStatement = (model: Model, field: ModelField): string | null => {
   if (field.required === true) statement += ' NOT NULL';
   if (typeof field.defaultValue !== 'undefined')
     statement += ` DEFAULT ${field.defaultValue}`;
+  if (field.collation) statement += ` COLLATE ${field.collation}`;
 
   if (typeof field.check !== 'undefined') {
     const symbol = getSymbol(field.check);

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -678,6 +678,7 @@ const getFieldStatement = (model: Model, field: ModelField): string | null => {
   if (typeof field.defaultValue !== 'undefined')
     statement += ` DEFAULT ${field.defaultValue}`;
   if (field.collation) statement += ` COLLATE ${field.collation}`;
+  if (field.increment === true) statement += ' AUTOINCREMENT';
 
   if (typeof field.check !== 'undefined') {
     const symbol = getSymbol(field.check);

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -26,6 +26,11 @@ test('create new model', () => {
       },
       collation: 'NOCASE',
     },
+    {
+      slug: 'position',
+      type: 'number',
+      increment: true,
+    },
   ];
 
   const queries: Array<Query> = [
@@ -48,7 +53,7 @@ test('create new model', () => {
   expect(statements).toEqual([
     {
       statement:
-        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL COLLATE NOCASE CHECK (length("handle") >= 3))',
+        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL COLLATE NOCASE CHECK (length("handle") >= 3), "position" INTEGER AUTOINCREMENT)',
       params: [],
     },
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -24,6 +24,7 @@ test('create new model', () => {
       check: {
         [RONIN_MODEL_SYMBOLS.EXPRESSION]: `length(${RONIN_MODEL_SYMBOLS.FIELD}handle) >= 3`,
       },
+      collation: 'NOCASE',
     },
   ];
 
@@ -47,7 +48,7 @@ test('create new model', () => {
   expect(statements).toEqual([
     {
       statement:
-        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL CHECK (length("handle") >= 3))',
+        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL COLLATE NOCASE CHECK (length("handle") >= 3))',
       params: [],
     },
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -31,6 +31,16 @@ test('create new model', () => {
       type: 'number',
       increment: true,
     },
+    {
+      slug: 'name',
+      type: 'string',
+      computedAs: {
+        kind: 'STORED',
+        value: {
+          [RONIN_MODEL_SYMBOLS.EXPRESSION]: `UPPER(substr(${RONIN_MODEL_SYMBOLS.FIELD}handle, 1, 1)) || substr(${RONIN_MODEL_SYMBOLS.FIELD}handle, 2)`,
+        },
+      },
+    },
   ];
 
   const queries: Array<Query> = [
@@ -53,7 +63,7 @@ test('create new model', () => {
   expect(statements).toEqual([
     {
       statement:
-        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL COLLATE NOCASE CHECK (length("handle") >= 3), "position" INTEGER AUTOINCREMENT)',
+        'CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "handle" TEXT, "email" TEXT UNIQUE NOT NULL COLLATE NOCASE CHECK (length("handle") >= 3), "position" INTEGER AUTOINCREMENT, "name" TEXT GENERATED ALWAYS AS (UPPER(substr("handle", 1, 1)) || substr("handle", 2)) STORED)',
       params: [],
     },
     {


### PR DESCRIPTION
This change adds a few more attributes/constraints that can be specified when adding fields to models:

- `collation`: The collation sequence for string fields.
- `increment`: Automatically increments number fields.
- `computedAs`: Allows for generating the value on read or on write using an expression.