### PR TITLE
Improved query types for object representations

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -144,7 +144,7 @@ export const handleTo = (
       const associativeModelSlug = composeAssociationModelSlug(model, fieldDetails.field);
 
       const composeStatement = (
-        subQueryType: 'create' | 'drop',
+        subQueryType: 'create' | 'delete',
         value?: unknown,
       ): Statement => {
         const source =
@@ -169,7 +169,7 @@ export const handleTo = (
       };
 
       if (Array.isArray(fieldValue)) {
-        dependencyStatements.push(composeStatement('drop'));
+        dependencyStatements.push(composeStatement('delete'));
 
         for (const record of fieldValue) {
           dependencyStatements.push(composeStatement('create', record));
@@ -180,7 +180,7 @@ export const handleTo = (
         }
 
         for (const recordToRemove of fieldValue.notContaining || []) {
-          dependencyStatements.push(composeStatement('drop', recordToRemove));
+          dependencyStatements.push(composeStatement('delete', recordToRemove));
         }
       }
     }

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -35,7 +35,7 @@ export const handleTo = (
   models: Array<Model>,
   model: Model,
   statementParams: Array<unknown> | null,
-  queryType: 'create' | 'set',
+  queryType: 'add' | 'set',
   dependencyStatements: Array<Statement>,
   instructions: {
     with: NonNullable<SetInstructions['with']> | undefined;
@@ -50,13 +50,13 @@ export const handleTo = (
 
   // If records are being created, assign a default ID to them, unless a custom ID was
   // already provided in the query.
-  if (queryType === 'create') {
+  if (queryType === 'add') {
     defaultFields.id = toInstruction.id || generateRecordId(model.idPrefix);
   }
 
   defaultFields.ronin = {
     // If records are being created, set their creation time.
-    ...(queryType === 'create' ? { createdAt: currentTime } : {}),
+    ...(queryType === 'add' ? { createdAt: currentTime } : {}),
     // If records are being created or updated, set their update time.
     updatedAt: currentTime,
     // Allow for overwriting the default values provided above.
@@ -144,11 +144,10 @@ export const handleTo = (
       const associativeModelSlug = composeAssociationModelSlug(model, fieldDetails.field);
 
       const composeStatement = (
-        subQueryType: 'create' | 'delete',
+        subQueryType: 'add' | 'delete',
         value?: unknown,
       ): Statement => {
-        const source =
-          queryType === 'create' ? { id: toInstruction.id } : withInstruction;
+        const source = queryType === 'add' ? { id: toInstruction.id } : withInstruction;
         const recordDetails: Record<string, unknown> = { source };
 
         if (value) recordDetails.target = value;
@@ -157,9 +156,7 @@ export const handleTo = (
           {
             [subQueryType]: {
               [associativeModelSlug]:
-                subQueryType === 'create'
-                  ? { to: recordDetails }
-                  : { with: recordDetails },
+                subQueryType === 'add' ? { to: recordDetails } : { with: recordDetails },
             },
           },
           models,
@@ -172,11 +169,11 @@ export const handleTo = (
         dependencyStatements.push(composeStatement('delete'));
 
         for (const record of fieldValue) {
-          dependencyStatements.push(composeStatement('create', record));
+          dependencyStatements.push(composeStatement('add', record));
         }
       } else if (isObject(fieldValue)) {
         for (const recordToAdd of fieldValue.containing || []) {
-          dependencyStatements.push(composeStatement('create', recordToAdd));
+          dependencyStatements.push(composeStatement('add', recordToAdd));
         }
 
         for (const recordToRemove of fieldValue.notContaining || []) {
@@ -188,10 +185,10 @@ export const handleTo = (
 
   let statement = composeConditions(models, model, statementParams, 'to', toInstruction, {
     parentModel,
-    type: queryType === 'create' ? 'fields' : undefined,
+    type: queryType === 'add' ? 'fields' : undefined,
   });
 
-  if (queryType === 'create') {
+  if (queryType === 'add') {
     const deepStatement = composeConditions(
       models,
       model,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,11 +1,11 @@
 import type {
+  AddInstructionsSchema,
+  AddQuerySchema,
   CombinedInstructionsSchema,
   CountInstructionsSchema,
   CountQuerySchema,
-  CreateInstructionsSchema,
-  CreateQuerySchema,
-  DropInstructionsSchema,
-  DropQuerySchema,
+  DeleteInstructionsSchema,
+  DeleteQuerySchema,
   ExpressionSchema,
   GetInstructionsSchema,
   GetQuerySchema,
@@ -33,13 +33,13 @@ export type GetInstructions = z.infer<typeof GetInstructionsSchema>;
 export type SetQuery = z.infer<typeof SetQuerySchema>;
 export type SetInstructions = z.infer<typeof SetInstructionsSchema>;
 
-// Create Queries.
-export type CreateQuery = z.infer<typeof CreateQuerySchema>;
-export type CreateInstructions = z.infer<typeof CreateInstructionsSchema>;
+// Add Queries.
+export type AddQuery = z.infer<typeof AddQuerySchema>;
+export type AddInstructions = z.infer<typeof AddInstructionsSchema>;
 
-// Drop Queries.
-export type DropQuery = z.infer<typeof DropQuerySchema>;
-export type DropInstructions = z.infer<typeof DropInstructionsSchema>;
+// Delete Queries.
+export type DeleteQuery = z.infer<typeof DeleteQuerySchema>;
+export type DeleteInstructions = z.infer<typeof DeleteInstructionsSchema>;
 
 // Count Queries.
 export type CountQuery = z.infer<typeof CountQuerySchema>;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -291,7 +291,7 @@ export const expand = (obj: NestedObject) => {
  * @returns The type, model, and instructions of the provided query.
  */
 export const splitQuery = (query: Query) => {
-  // The type of query that is being executed (`create`, `get`, etc).
+  // The type of query that is being executed (`add`, `get`, etc).
   const queryType = Object.keys(query)[0] as QueryType;
 
   // The slug or plural slug of the RONIN model that the query will interact with.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -93,7 +93,7 @@ export const compileQueryInput = (
       statement += 'DELETE FROM ';
       break;
 
-    case 'create':
+    case 'add':
       statement += 'INSERT INTO ';
       break;
 
@@ -128,7 +128,7 @@ export const compileQueryInput = (
     statement += `"${model.table}" `;
   }
 
-  if (queryType === 'create' || queryType === 'set') {
+  if (queryType === 'add' || queryType === 'set') {
     // This validation must be performed before any default fields (such as `ronin`) are
     // added to the record. Otherwise there are always fields present.
     if (!isObject(instructions.to) || Object.keys(instructions.to).length === 0) {
@@ -155,8 +155,8 @@ export const compileQueryInput = (
   const conditions: Array<string> = [];
 
   // Queries of type "get", "set", "delete", or "count" all support filtering records,
-  // but those of type "create" do not.
-  if (queryType !== 'create' && instructions && Object.hasOwn(instructions, 'with')) {
+  // but those of type "add" do not.
+  if (queryType !== 'add' && instructions && Object.hasOwn(instructions, 'with')) {
     const withStatement = handleWith(
       models,
       model,
@@ -249,7 +249,7 @@ export const compileQueryInput = (
 
   // For queries that modify records, we want to make sure that the modified record is
   // returned after the modification has been performed.
-  if (['create', 'set', 'delete'].includes(queryType) && returning) {
+  if (['add', 'set', 'delete'].includes(queryType) && returning) {
     statement += 'RETURNING * ';
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -89,7 +89,7 @@ export const compileQueryInput = (
       statement += `SELECT COUNT(${columns}) FROM `;
       break;
 
-    case 'drop':
+    case 'delete':
       statement += 'DELETE FROM ';
       break;
 
@@ -154,8 +154,8 @@ export const compileQueryInput = (
 
   const conditions: Array<string> = [];
 
-  // Queries of type "get", "set", "drop", or "count" all support filtering records, but
-  // those of type "create" do not.
+  // Queries of type "get", "set", "delete", or "count" all support filtering records,
+  // but those of type "create" do not.
   if (queryType !== 'create' && instructions && Object.hasOwn(instructions, 'with')) {
     const withStatement = handleWith(
       models,
@@ -249,7 +249,7 @@ export const compileQueryInput = (
 
   // For queries that modify records, we want to make sure that the modified record is
   // returned after the modification has been performed.
-  if (['create', 'set', 'drop'].includes(queryType) && returning) {
+  if (['create', 'set', 'delete'].includes(queryType) && returning) {
     statement += 'RETURNING * ';
   }
 

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -8,7 +8,7 @@ import {
 } from '@/src/utils/model';
 
 /**
- * Handles queries that modify the database schema. Specifically, those are `add.model`,
+ * Handles queries that modify the DB schema. Specifically, those are `create.model`,
  * `alter.model`, and `drop.model` queries.
  *
  * @param models - A list of models.
@@ -23,11 +23,11 @@ export const transformMetaQuery = (
   dependencyStatements: Array<Statement>,
   query: Query,
 ): Query => {
-  if (query.add) {
-    const init = query.add.model;
+  if (query.create) {
+    const init = query.create.model;
     const details =
-      'options' in query.add
-        ? ({ slug: init, ...query.add.options } as PartialModel)
+      'options' in query.create
+        ? ({ slug: init, ...query.create.options } as PartialModel)
         : (init as PartialModel);
 
     // Compose default settings for the model.
@@ -39,13 +39,13 @@ export const transformMetaQuery = (
     };
 
     addModelQueries(models, dependencyStatements, {
-      queryType: 'create',
+      queryType: 'add',
       queryModel: 'model',
       queryInstructions: instructions,
     });
 
     return {
-      create: {
+      add: {
         model: instructions,
       },
     };
@@ -97,9 +97,9 @@ export const transformMetaQuery = (
       };
     }
 
-    if ('add' in query.alter) {
-      const type = Object.keys(query.alter.add)[0] as ModelEntity;
-      const item = query.alter.add[type] as Partial<ModelIndex>;
+    if ('create' in query.alter) {
+      const type = Object.keys(query.alter.create)[0] as ModelEntity;
+      const item = query.alter.create[type] as Partial<ModelIndex>;
       const completeItem = { slug: item.slug || `${type}_slug`, ...item };
 
       const instructions = {
@@ -110,13 +110,13 @@ export const transformMetaQuery = (
       };
 
       addModelQueries(models, dependencyStatements, {
-        queryType: 'create',
+        queryType: 'add',
         queryModel: type,
         queryInstructions: instructions,
       });
 
       return {
-        create: {
+        add: {
           [type]: instructions,
         },
       };

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -59,13 +59,13 @@ export const transformMetaQuery = (
     };
 
     addModelQueries(models, dependencyStatements, {
-      queryType: 'drop',
+      queryType: 'delete',
       queryModel: 'model',
       queryInstructions: instructions,
     });
 
     return {
-      drop: {
+      delete: {
         model: instructions,
       },
     };
@@ -153,13 +153,13 @@ export const transformMetaQuery = (
     };
 
     addModelQueries(models, dependencyStatements, {
-      queryType: 'drop',
+      queryType: 'delete',
       queryModel: type,
       queryInstructions: instructions,
     });
 
     return {
-      drop: {
+      delete: {
         [type]: instructions,
       },
     };

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * Handles queries that modify the database schema. Specifically, those are `add.model`,
- * `alter.model`, and `remove.model` queries.
+ * `alter.model`, and `drop.model` queries.
  *
  * @param models - A list of models.
  * @param dependencyStatements - A list of SQL statements to be executed before the main
@@ -51,8 +51,8 @@ export const transformMetaQuery = (
     };
   }
 
-  if (query.remove) {
-    const slug = query.remove.model;
+  if (query.drop) {
+    const slug = query.drop.model;
 
     const instructions = {
       with: { slug },
@@ -145,8 +145,8 @@ export const transformMetaQuery = (
       };
     }
 
-    const type = Object.keys(query.alter.remove)[0] as ModelEntity;
-    const itemSlug = query.alter.remove[type] as string;
+    const type = Object.keys(query.alter.drop)[0] as ModelEntity;
+    const itemSlug = query.alter.drop[type] as string;
 
     const instructions = {
       with: { model: { slug }, slug: itemSlug },

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -641,7 +641,7 @@ type QueryInstructionTypeClean = Exclude<
  * the `with` instruction.
  */
 const mappedInstructions: Partial<Record<QueryType, QueryInstructionTypeClean>> = {
-  create: 'to',
+  add: 'to',
   set: 'with',
   delete: 'with',
 };
@@ -733,7 +733,7 @@ export const addModelQueries = (
   const { queryType, queryModel, queryInstructions } = queryDetails;
 
   // Only continue if the query is a write query.
-  if (!['create', 'set', 'delete'].includes(queryType)) return;
+  if (!['add', 'set', 'delete'].includes(queryType)) return;
 
   // Only continue if the query addresses system models.
   if (!SYSTEM_MODEL_SLUGS.includes(queryModel)) return;
@@ -748,7 +748,7 @@ export const addModelQueries = (
   let queryTypeReadable: string | null = null;
 
   switch (queryType) {
-    case 'create': {
+    case 'add': {
       if (kind === 'models' || kind === 'indexes' || kind === 'triggers') {
         tableAction = 'CREATE';
       }
@@ -779,9 +779,7 @@ export const addModelQueries = (
   const usableSlug = kind === 'models' ? slug : modelSlug;
   const tableName = convertToSnakeCase(pluralize(usableSlug));
   const targetModel =
-    kind === 'models' && queryType === 'create'
-      ? null
-      : getModelBySlug(models, usableSlug);
+    kind === 'models' && queryType === 'add' ? null : getModelBySlug(models, usableSlug);
 
   if (kind === 'indexes') {
     const indexName = convertToSnakeCase(slug);
@@ -798,7 +796,7 @@ export const addModelQueries = (
     const params: Array<unknown> = [];
     let statement = `${tableAction}${unique ? ' UNIQUE' : ''} INDEX "${indexName}"`;
 
-    if (queryType === 'create') {
+    if (queryType === 'add') {
       const model = targetModel as Model;
       const columns = fields.map((field) => {
         let fieldSelector = '';
@@ -847,7 +845,7 @@ export const addModelQueries = (
     const params: Array<unknown> = [];
     let statement = `${tableAction} TRIGGER "${triggerName}"`;
 
-    if (queryType === 'create') {
+    if (queryType === 'add') {
       const currentModel = targetModel as Model;
 
       // When the trigger should fire and what type of query should cause it to fire.
@@ -936,7 +934,7 @@ export const addModelQueries = (
   const statement = `${tableAction} TABLE "${tableName}"`;
 
   if (kind === 'models') {
-    if (queryType === 'create') {
+    if (queryType === 'add') {
       const newModel = queryInstructions.to as Model;
       const { fields } = newModel;
       const columns = fields
@@ -977,7 +975,7 @@ export const addModelQueries = (
   }
 
   if (kind === 'fields') {
-    if (queryType === 'create') {
+    if (queryType === 'add') {
       // Default field type.
       if (!instructionList.type) instructionList.type = 'string';
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -643,7 +643,7 @@ type QueryInstructionTypeClean = Exclude<
 const mappedInstructions: Partial<Record<QueryType, QueryInstructionTypeClean>> = {
   create: 'to',
   set: 'with',
-  drop: 'with',
+  delete: 'with',
 };
 
 /** A list of all RONIN data types and their respective column types in SQLite. */
@@ -733,7 +733,7 @@ export const addModelQueries = (
   const { queryType, queryModel, queryInstructions } = queryDetails;
 
   // Only continue if the query is a write query.
-  if (!['create', 'set', 'drop'].includes(queryType)) return;
+  if (!['create', 'set', 'delete'].includes(queryType)) return;
 
   // Only continue if the query addresses system models.
   if (!SYSTEM_MODEL_SLUGS.includes(queryModel)) return;
@@ -762,7 +762,7 @@ export const addModelQueries = (
       break;
     }
 
-    case 'drop': {
+    case 'delete': {
       if (kind === 'models' || kind === 'indexes' || kind === 'triggers') {
         tableAction = 'DROP';
       }
@@ -966,7 +966,7 @@ export const addModelQueries = (
 
       // Update the existing model in the list of models.
       Object.assign(targetModel as Model, queryInstructions.to);
-    } else if (queryType === 'drop') {
+    } else if (queryType === 'delete') {
       // Remove the model from the list of models.
       models.splice(models.indexOf(targetModel as Model), 1);
 
@@ -996,7 +996,7 @@ export const addModelQueries = (
           params: [],
         });
       }
-    } else if (queryType === 'drop') {
+    } else if (queryType === 'delete') {
       dependencyStatements.push({
         statement: `${statement} DROP COLUMN "${slug}"`,
         params: [],

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -2,10 +2,10 @@ import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 import { z } from 'zod';
 
 // Query Types.
-export const QueryTypeEnum = z.enum(['get', 'set', 'delete', 'create', 'count']);
+export const QueryTypeEnum = z.enum(['get', 'set', 'add', 'delete', 'count']);
 
 // Model Query Types.
-export const ModelQueryTypeEnum = z.enum(['add', 'alter', 'drop']);
+export const ModelQueryTypeEnum = z.enum(['create', 'alter', 'drop']);
 export const ModelEntityEnum = z.enum(['field', 'index', 'trigger', 'preset']);
 
 // Record.
@@ -243,7 +243,7 @@ export const CreateInstructionsSchema = InstructionsSchema.partial()
     ),
   });
 export const CreateQuerySchema = z.object({
-  create: z.record(z.string(), CreateInstructionsSchema),
+  add: z.record(z.string(), CreateInstructionsSchema),
 });
 
 // Drop Queries.
@@ -288,13 +288,13 @@ export const QuerySchemaSchema = z.record(InstructionsSchema.partial());
 
 export const QuerySchema = z
   .object({
-    [QueryTypeEnum.Enum.count]: z.record(z.string(), CountInstructionsSchema.nullable()),
-    [QueryTypeEnum.Enum.create]: z.record(z.string(), CreateInstructionsSchema),
-    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DropInstructionsSchema),
     [QueryTypeEnum.Enum.get]: z.record(z.string(), GetInstructionsSchema.nullable()),
     [QueryTypeEnum.Enum.set]: z.record(z.string(), SetInstructionsSchema),
+    [QueryTypeEnum.Enum.add]: z.record(z.string(), CreateInstructionsSchema),
+    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DropInstructionsSchema),
+    [QueryTypeEnum.Enum.count]: z.record(z.string(), CountInstructionsSchema.nullable()),
 
-    [ModelQueryTypeEnum.Enum.add]: z.union([
+    [ModelQueryTypeEnum.Enum.create]: z.union([
       z.object({
         model: z.string(),
         options: z.record(z.string(), z.any()),
@@ -314,7 +314,7 @@ export const QuerySchema = z
             options: z.record(z.string(), z.any()),
           }),
           z.object({
-            [ModelQueryTypeEnum.Enum.add]: z.union([
+            [ModelQueryTypeEnum.Enum.create]: z.union([
               z.record(ModelEntityEnum, z.string()).and(
                 z.object({
                   options: z.record(z.string(), z.any()),

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -2,7 +2,7 @@ import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 import { z } from 'zod';
 
 // Query Types.
-export const QueryTypeEnum = z.enum(['get', 'set', 'drop', 'create', 'count']);
+export const QueryTypeEnum = z.enum(['get', 'set', 'delete', 'create', 'count']);
 
 // Model Query Types.
 export const ModelQueryTypeEnum = z.enum(['add', 'alter', 'remove']);
@@ -251,7 +251,7 @@ export const DropInstructionsSchema = InstructionsSchema.partial().omit({
   to: true,
 });
 export const DropQuerySchema = z.object({
-  drop: z.record(z.string(), DropInstructionsSchema),
+  delete: z.record(z.string(), DropInstructionsSchema),
 });
 
 // Count Queries.
@@ -290,7 +290,7 @@ export const QuerySchema = z
   .object({
     [QueryTypeEnum.Enum.count]: z.record(z.string(), CountInstructionsSchema.nullable()),
     [QueryTypeEnum.Enum.create]: z.record(z.string(), CreateInstructionsSchema),
-    [QueryTypeEnum.Enum.drop]: z.record(z.string(), DropInstructionsSchema),
+    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DropInstructionsSchema),
     [QueryTypeEnum.Enum.get]: z.record(z.string(), GetInstructionsSchema.nullable()),
     [QueryTypeEnum.Enum.set]: z.record(z.string(), SetInstructionsSchema),
 

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -233,8 +233,8 @@ export const SetQuerySchema = z.object({
   set: z.record(z.string(), SetInstructionsSchema),
 });
 
-// Create Queries.
-export const CreateInstructionsSchema = InstructionsSchema.partial()
+// Add Queries.
+export const AddInstructionsSchema = InstructionsSchema.partial()
   .omit({ with: true, for: true })
   .extend({
     to: FieldSelector.refine(
@@ -242,16 +242,16 @@ export const CreateInstructionsSchema = InstructionsSchema.partial()
       'The `to` instruction must not be empty.',
     ),
   });
-export const CreateQuerySchema = z.object({
-  add: z.record(z.string(), CreateInstructionsSchema),
+export const AddQuerySchema = z.object({
+  add: z.record(z.string(), AddInstructionsSchema),
 });
 
 // Drop Queries.
-export const DropInstructionsSchema = InstructionsSchema.partial().omit({
+export const DeleteInstructionsSchema = InstructionsSchema.partial().omit({
   to: true,
 });
-export const DropQuerySchema = z.object({
-  delete: z.record(z.string(), DropInstructionsSchema),
+export const DeleteQuerySchema = z.object({
+  delete: z.record(z.string(), DeleteInstructionsSchema),
 });
 
 // Count Queries.
@@ -266,8 +266,8 @@ export const CountQuerySchema = z.object({
 export const CombinedInstructionsSchema = z.union([
   SetInstructionsSchema,
   CountInstructionsSchema,
-  CreateInstructionsSchema,
-  DropInstructionsSchema,
+  AddInstructionsSchema,
+  DeleteInstructionsSchema,
   GetInstructionsSchema,
 ]);
 export const InstructionSchema = z.enum([
@@ -290,8 +290,8 @@ export const QuerySchema = z
   .object({
     [QueryTypeEnum.Enum.get]: z.record(z.string(), GetInstructionsSchema.nullable()),
     [QueryTypeEnum.Enum.set]: z.record(z.string(), SetInstructionsSchema),
-    [QueryTypeEnum.Enum.add]: z.record(z.string(), CreateInstructionsSchema),
-    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DropInstructionsSchema),
+    [QueryTypeEnum.Enum.add]: z.record(z.string(), AddInstructionsSchema),
+    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DeleteInstructionsSchema),
     [QueryTypeEnum.Enum.count]: z.record(z.string(), CountInstructionsSchema.nullable()),
 
     [ModelQueryTypeEnum.Enum.create]: z.union([

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 export const QueryTypeEnum = z.enum(['get', 'set', 'delete', 'create', 'count']);
 
 // Model Query Types.
-export const ModelQueryTypeEnum = z.enum(['add', 'alter', 'remove']);
+export const ModelQueryTypeEnum = z.enum(['add', 'alter', 'drop']);
 export const ModelEntityEnum = z.enum(['field', 'index', 'trigger', 'preset']);
 
 // Record.
@@ -331,12 +331,12 @@ export const QuerySchema = z
             ),
           }),
           z.object({
-            [ModelQueryTypeEnum.Enum.remove]: z.record(ModelEntityEnum, z.string()),
+            [ModelQueryTypeEnum.Enum.drop]: z.record(ModelEntityEnum, z.string()),
           }),
         ]),
       ),
 
-    [ModelQueryTypeEnum.Enum.remove]: z.object({
+    [ModelQueryTypeEnum.Enum.drop]: z.object({
       model: z.string(),
     }),
   })

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -147,10 +147,10 @@ test('set single record with empty `to` instruction', () => {
   expect(error).toHaveProperty('code', 'INVALID_TO_VALUE');
 });
 
-test('create single record with empty `to` instruction', () => {
+test('add single record with empty `to` instruction', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         account: {
           to: {},
         },
@@ -175,7 +175,7 @@ test('create single record with empty `to` instruction', () => {
   expect(error).toBeInstanceOf(RoninError);
   expect(error).toHaveProperty(
     'message',
-    'When using a `create` query, the `to` instruction must be a non-empty object.',
+    'When using a `add` query, the `to` instruction must be a non-empty object.',
   );
   expect(error).toHaveProperty('code', 'INVALID_TO_VALUE');
 });

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -657,10 +657,10 @@ test('set single record to result of nested query', () => {
   ]);
 });
 
-test('create multiple records with nested sub query', () => {
+test('add multiple records with nested sub query', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         newAccounts: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {
@@ -706,10 +706,10 @@ test('create multiple records with nested sub query', () => {
   ]);
 });
 
-test('create multiple records with nested sub query including additional fields', () => {
+test('add multiple records with nested sub query including additional fields', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         newAccounts: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {
@@ -764,10 +764,10 @@ test('create multiple records with nested sub query including additional fields'
   ]);
 });
 
-test('create multiple records with nested sub query and specific fields', () => {
+test('add multiple records with nested sub query and specific fields', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         newAccounts: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {
@@ -820,10 +820,10 @@ test('create multiple records with nested sub query and specific fields', () => 
   ]);
 });
 
-test('create multiple records with nested sub query and specific meta fields', () => {
+test('add multiple records with nested sub query and specific meta fields', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         newAccounts: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {
@@ -877,10 +877,10 @@ test('create multiple records with nested sub query and specific meta fields', (
 
 // Ensure that an error is thrown for fields that don't exist in the target model, since
 // the value of the field cannot be used in those cases.
-test('try to create multiple records with nested sub query including non-existent fields', () => {
+test('try to add multiple records with nested sub query including non-existent fields', () => {
   const queries: Array<Query> = [
     {
-      create: {
+      add: {
         newAccounts: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -195,10 +195,10 @@ test('update existing model (plural name)', () => {
   ]);
 });
 
-test('remove existing model', () => {
+test('drop existing model', () => {
   const queries: Array<Query> = [
     {
-      remove: {
+      drop: {
         model: 'account',
       },
     },
@@ -287,7 +287,7 @@ test('query a model that was just updated', () => {
 test('query a model that was just dropped', () => {
   const queries: Array<Query> = [
     {
-      remove: {
+      drop: {
         model: 'account',
       },
     },
@@ -501,12 +501,12 @@ test('update existing field (name)', () => {
   ]);
 });
 
-test('remove existing field', () => {
+test('drop existing field', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
-        remove: {
+        drop: {
           field: 'email',
         },
       },
@@ -801,12 +801,12 @@ test('add new unique index', () => {
   ]);
 });
 
-test('remove existing index', () => {
+test('drop existing index', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
-        remove: {
+        drop: {
           index: 'index_slug',
         },
       },
@@ -1319,12 +1319,12 @@ test('add new per-record trigger with filters for creating records', () => {
   ]);
 });
 
-test('remove existing trigger', () => {
+test('drop existing trigger', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'team',
-        remove: {
+        drop: {
           trigger: 'trigger_slug',
         },
       },
@@ -1447,12 +1447,12 @@ test('update existing preset', () => {
   ]);
 });
 
-test('remove existing preset', () => {
+test('drop existing preset', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
-        remove: {
+        drop: {
           preset: 'company_employees',
         },
       },

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1155,7 +1155,7 @@ test('add new per-record trigger for creating records', () => {
 test('add new per-record trigger for deleting records', () => {
   const effectQueries = [
     {
-      drop: {
+      delete: {
         members: {
           with: {
             account: {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -10,7 +10,7 @@ import {
 import { RECORD_ID_REGEX } from '@/src/utils/helpers';
 import { SYSTEM_FIELDS } from '@/src/utils/model';
 
-test('add new model', () => {
+test('create new model', () => {
   const fields = [
     {
       slug: 'handle',
@@ -45,7 +45,7 @@ test('add new model', () => {
 
   const queries: Array<Query> = [
     {
-      add: {
+      create: {
         model: 'account',
         options: { fields },
       },
@@ -86,7 +86,7 @@ test('add new model', () => {
 
 // Ensure that a reasonable display name and URL slug are automatically selected for the
 // model, based on which fields are available.
-test('add new model with suitable default identifiers', () => {
+test('create new model with suitable default identifiers', () => {
   const fields = [
     {
       slug: 'name',
@@ -103,7 +103,7 @@ test('add new model with suitable default identifiers', () => {
 
   const queries: Array<Query> = [
     {
-      add: {
+      create: {
         model: 'account',
         options: { fields },
       },
@@ -228,7 +228,7 @@ test('drop existing model', () => {
 test('query a model that was just created', () => {
   const queries: Array<Query> = [
     {
-      add: {
+      create: {
         model: {
           slug: 'account',
         },
@@ -320,12 +320,12 @@ test('query a model that was just dropped', () => {
   expect(error).toHaveProperty('code', 'MODEL_NOT_FOUND');
 });
 
-test('add new field', () => {
+test('create new field', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           field: {
             slug: 'email',
           },
@@ -363,12 +363,12 @@ test('add new field', () => {
   ]);
 });
 
-test('add new field with options', () => {
+test('create new field with options', () => {
   const queries: Array<Query> = [
     {
       alter: {
         model: 'member',
-        add: {
+        create: {
           field: {
             slug: 'account',
             type: 'link',
@@ -535,7 +535,7 @@ test('drop existing field', () => {
   ]);
 });
 
-test('add new index', () => {
+test('create new index', () => {
   const fields = [
     {
       slug: 'email',
@@ -546,7 +546,7 @@ test('add new index', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           index: { fields },
         },
       },
@@ -583,7 +583,7 @@ test('add new index', () => {
   ]);
 });
 
-test('add new index with filter', () => {
+test('create new index with filter', () => {
   const fields = [
     {
       slug: 'email',
@@ -600,7 +600,7 @@ test('add new index with filter', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           index: {
             fields,
             filter: filterInstruction,
@@ -642,7 +642,7 @@ test('add new index with filter', () => {
   ]);
 });
 
-test('add new index with field expressions', () => {
+test('create new index with field expressions', () => {
   const fields = [
     {
       expression: `LOWER(${RONIN_MODEL_SYMBOLS.FIELD}firstName || ' ' || ${RONIN_MODEL_SYMBOLS.FIELD}lastName)`,
@@ -653,7 +653,7 @@ test('add new index with field expressions', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           index: { fields },
         },
       },
@@ -699,7 +699,7 @@ test('add new index with field expressions', () => {
   ]);
 });
 
-test('add new index with ordered and collated fields', () => {
+test('create new index with ordered and collated fields', () => {
   const fields = [
     {
       slug: 'email',
@@ -712,7 +712,7 @@ test('add new index with ordered and collated fields', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           index: { fields },
         },
       },
@@ -749,7 +749,7 @@ test('add new index with ordered and collated fields', () => {
   ]);
 });
 
-test('add new unique index', () => {
+test('create new unique index', () => {
   const fields = [
     {
       slug: 'email',
@@ -760,7 +760,7 @@ test('add new unique index', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           index: {
             fields,
             unique: true,
@@ -835,10 +835,10 @@ test('drop existing index', () => {
   ]);
 });
 
-test('add new trigger for creating records', () => {
+test('create new trigger for creating records', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         signup: {
           to: {
             year: 2000,
@@ -852,7 +852,7 @@ test('add new trigger for creating records', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'INSERT',
@@ -904,10 +904,10 @@ test('add new trigger for creating records', () => {
   ]);
 });
 
-test('add new trigger for creating records with targeted fields', () => {
+test('create new trigger for creating records with targeted fields', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         signup: {
           to: {
             year: 2000,
@@ -927,7 +927,7 @@ test('add new trigger for creating records with targeted fields', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'UPDATE',
@@ -982,10 +982,10 @@ test('add new trigger for creating records with targeted fields', () => {
   ]);
 });
 
-test('add new trigger for creating records with multiple effects', () => {
+test('create new trigger for creating records with multiple effects', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         signup: {
           to: {
             year: 2000,
@@ -994,7 +994,7 @@ test('add new trigger for creating records with multiple effects', () => {
       },
     },
     {
-      create: {
+      add: {
         candidate: {
           to: {
             year: 2020,
@@ -1008,7 +1008,7 @@ test('add new trigger for creating records with multiple effects', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'INSERT',
@@ -1068,10 +1068,10 @@ test('add new trigger for creating records with multiple effects', () => {
   ]);
 });
 
-test('add new per-record trigger for creating records', () => {
+test('create new per-record trigger for creating records', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         member: {
           to: {
             account: {
@@ -1089,7 +1089,7 @@ test('add new per-record trigger for creating records', () => {
     {
       alter: {
         model: 'team',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'INSERT',
@@ -1152,7 +1152,7 @@ test('add new per-record trigger for creating records', () => {
   ]);
 });
 
-test('add new per-record trigger for deleting records', () => {
+test('create new per-record trigger for deleting records', () => {
   const effectQueries = [
     {
       delete: {
@@ -1171,7 +1171,7 @@ test('add new per-record trigger for deleting records', () => {
     {
       alter: {
         model: 'team',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'DELETE',
@@ -1228,10 +1228,10 @@ test('add new per-record trigger for deleting records', () => {
   ]);
 });
 
-test('add new per-record trigger with filters for creating records', () => {
+test('create new per-record trigger with filters for creating records', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         member: {
           to: {
             account: {
@@ -1255,7 +1255,7 @@ test('add new per-record trigger with filters for creating records', () => {
     {
       alter: {
         model: 'team',
-        add: {
+        create: {
           trigger: {
             when: 'AFTER',
             action: 'INSERT',
@@ -1353,7 +1353,7 @@ test('drop existing trigger', () => {
   ]);
 });
 
-test('add new preset', () => {
+test('create new preset', () => {
   const instructions = {
     with: {
       email: {
@@ -1366,7 +1366,7 @@ test('add new preset', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           preset: {
             slug: 'company_employees',
             instructions,
@@ -1507,10 +1507,10 @@ test('try to update existing model that does not exist', () => {
   expect(error).toHaveProperty('code', 'MODEL_NOT_FOUND');
 });
 
-test('try to add new trigger with targeted fields and wrong action', () => {
+test('try to create new trigger with targeted fields and wrong action', () => {
   const effectQueries = [
     {
-      create: {
+      add: {
         signup: {
           to: {
             year: 2000,
@@ -1524,7 +1524,7 @@ test('try to add new trigger with targeted fields and wrong action', () => {
     {
       alter: {
         model: 'account',
-        add: {
+        create: {
           trigger: {
             model: { slug: 'account' },
             when: 'AFTER',

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -28,10 +28,10 @@ test('get single record', () => {
   ]);
 });
 
-test('drop single record', () => {
+test('delete single record', () => {
   const queries: Array<Query> = [
     {
-      drop: {
+      delete: {
         account: {
           with: {
             handle: 'elaine',


### PR DESCRIPTION
To prevent confusion when running queries that update the DB schema, this change evaluates aligning the query type names of the object representations of schema-modification queries further with SQLite.

In other words, the query types `create` and `drop` are now used for schema operations instead of basic operations, to avoid mixing the terminology. For example, `drop.accounts` previously sounded like you might be dropping the entire "accounts" table, to someone familiar with SQL.

## Basic Operations

- `get` => `SELECT`
- `set` => `UPDATE ... SET`
- `add` => `INSERT`
- `delete` => `DELETE`
- `count` => `SELECT COUNT(*)`

## Schema Operations

- `create.model` => `CREATE TABLE`
- `alter.model` => `ALTER TABLE`
- `drop.model` => `DROP TABLE`