### PR TITLE
Improved object representation for schema changes further

### DIFF
--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -26,8 +26,8 @@ export const transformMetaQuery = (
   if (query.create) {
     const init = query.create.model;
     const details =
-      'options' in query.create
-        ? ({ slug: init, ...query.create.options } as PartialModel)
+      'to' in query.create
+        ? ({ slug: init, ...query.create.to } as PartialModel)
         : (init as PartialModel);
 
     // Compose default settings for the model.
@@ -74,9 +74,9 @@ export const transformMetaQuery = (
   if (query.alter) {
     const slug = query.alter.model;
 
-    if ('options' in query.alter) {
+    if ('to' in query.alter) {
       // Compose default settings for the model.
-      const modelWithFields = addDefaultModelFields(query.alter.options, false);
+      const modelWithFields = addDefaultModelFields(query.alter.to, false);
       const modelWithPresets = addDefaultModelPresets(models, modelWithFields);
 
       const instructions = {
@@ -125,7 +125,7 @@ export const transformMetaQuery = (
     if ('alter' in query.alter) {
       const type = Object.keys(query.alter.alter)[0] as ModelEntity;
       const itemSlug = query.alter.alter[type];
-      const newItem = query.alter.alter.options;
+      const newItem = query.alter.alter.to;
 
       const instructions = {
         with: { model: { slug }, slug: itemSlug },

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -297,7 +297,7 @@ export const QuerySchema = z
     [ModelQueryTypeEnum.Enum.create]: z.union([
       z.object({
         model: z.string(),
-        options: z.record(z.string(), z.any()),
+        to: z.record(z.string(), z.any()),
       }),
       z.object({
         model: z.record(z.string(), z.any()),
@@ -311,13 +311,13 @@ export const QuerySchema = z
       .and(
         z.union([
           z.object({
-            options: z.record(z.string(), z.any()),
+            to: z.record(z.string(), z.any()),
           }),
           z.object({
             [ModelQueryTypeEnum.Enum.create]: z.union([
               z.record(ModelEntityEnum, z.string()).and(
                 z.object({
-                  options: z.record(z.string(), z.any()),
+                  to: z.record(z.string(), z.any()),
                 }),
               ),
               z.record(ModelEntityEnum, z.record(z.string(), z.any())),
@@ -326,7 +326,7 @@ export const QuerySchema = z
           z.object({
             [ModelQueryTypeEnum.Enum.alter]: z.record(ModelEntityEnum, z.string()).and(
               z.object({
-                options: z.record(z.string(), z.any()),
+                to: z.record(z.string(), z.any()),
               }),
             ),
           }),

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -46,8 +46,7 @@ test('create new model', () => {
   const queries: Array<Query> = [
     {
       create: {
-        model: 'account',
-        options: { fields },
+        model: { slug: 'account', fields },
       },
     },
   ];
@@ -104,8 +103,7 @@ test('create new model with suitable default identifiers', () => {
   const queries: Array<Query> = [
     {
       create: {
-        model: 'account',
-        options: { fields },
+        model: { slug: 'account', fields },
       },
     },
   ];
@@ -125,7 +123,7 @@ test('update existing model (slug)', () => {
     {
       alter: {
         model: 'account',
-        options: {
+        to: {
           slug: 'user',
         },
       },
@@ -170,7 +168,7 @@ test('update existing model (plural name)', () => {
     {
       alter: {
         model: 'account',
-        options: {
+        to: {
           pluralName: 'Signups',
         },
       },
@@ -257,7 +255,7 @@ test('query a model that was just updated', () => {
     {
       alter: {
         model: 'account',
-        options: {
+        to: {
           slug: 'user',
         },
       },
@@ -426,7 +424,7 @@ test('update existing field (slug)', () => {
         model: 'account',
         alter: {
           field: 'email',
-          options: {
+          to: {
             slug: 'emailAddress',
           },
         },
@@ -470,7 +468,7 @@ test('update existing field (name)', () => {
         model: 'account',
         alter: {
           field: 'email',
-          options: {
+          to: {
             name: 'Email Address',
           },
         },
@@ -1417,7 +1415,7 @@ test('update existing preset', () => {
         model: 'account',
         alter: {
           preset: 'company_employees',
-          options: { instructions },
+          to: { instructions },
         },
       },
     },
@@ -1482,7 +1480,7 @@ test('try to update existing model that does not exist', () => {
     {
       alter: {
         model: 'account',
-        options: {
+        to: {
           slug: 'user',
         },
       },


### PR DESCRIPTION
This change applies another incremental improvement to the object representation of queries that can modify the database schema, which results in the TS syntax shown below.

Note that the syntax is not specifically implemented in the TS client. It is merely a result of the compiler supporting the associated object representation and the TS client now supporting functional chaining (https://github.com/ronin-co/client/pull/145).

Soon, we'll improve this syntax even further, but that requires adapting the rest of the syntax as well, not just the syntax for modifying the database schema. For example, I would like the objects to be passable as a second function argument instead of using the `to` method, but that argument is currently used to provide options (like the token) to the TS client in our queries, so we'll first need to find a solution for that.

## Preview

```typescript
create.model({ slug: 'account', fields: [{ name: 'string' }] });
alter.model('account').to({ name: 'string' });
drop.model('account');

alter.model('account').create.field({ slug: 'test', type: 'string' });
alter.model('account').create.index({ fields: [{ slug: 'test' }] });
alter.model('account').create.trigger({ when: 'BEFORE', action: 'INSERT', effects: [...] });
alter.model('account').create.preset({ slug: 'test', instructions: { with: { handle: 'test' }}});

alter.model('account').alter.field('test').to({ name: 'Test' });
alter.model('account').alter.index('test').to({ fields: [{ slug: 'newTest' }] });
alter.model('account').alter.trigger('test').to({ when: 'BEFORE' });
alter.model('account').alter.preset('test').to({ instructions: { with: { handle: 'newTest' }} });

alter.model('account').drop.field('test');
alter.model('account').drop.index('test');
alter.model('account').drop.trigger('test');
alter.model('account').drop.preset('test');
```