### PR TITLE
Replaced reserved query type with different one

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -144,7 +144,7 @@ export const handleTo = (
       const associativeModelSlug = composeAssociationModelSlug(model, fieldDetails.field);
 
       const composeStatement = (
-        subQueryType: 'add' | 'delete',
+        subQueryType: 'add' | 'remove',
         value?: unknown,
       ): Statement => {
         const source = queryType === 'add' ? { id: toInstruction.id } : withInstruction;
@@ -166,7 +166,7 @@ export const handleTo = (
       };
 
       if (Array.isArray(fieldValue)) {
-        dependencyStatements.push(composeStatement('delete'));
+        dependencyStatements.push(composeStatement('remove'));
 
         for (const record of fieldValue) {
           dependencyStatements.push(composeStatement('add', record));
@@ -177,7 +177,7 @@ export const handleTo = (
         }
 
         for (const recordToRemove of fieldValue.notContaining || []) {
-          dependencyStatements.push(composeStatement('delete', recordToRemove));
+          dependencyStatements.push(composeStatement('remove', recordToRemove));
         }
       }
     }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -37,7 +37,7 @@ export type SetInstructions = z.infer<typeof SetInstructionsSchema>;
 export type AddQuery = z.infer<typeof AddQuerySchema>;
 export type AddInstructions = z.infer<typeof AddInstructionsSchema>;
 
-// Delete Queries.
+// Remove Queries.
 export type RemoveQuery = z.infer<typeof RemoveQuerySchema>;
 export type RemoveInstructions = z.infer<typeof RemoveInstructionsSchema>;
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -4,8 +4,6 @@ import type {
   CombinedInstructionsSchema,
   CountInstructionsSchema,
   CountQuerySchema,
-  DeleteInstructionsSchema,
-  DeleteQuerySchema,
   ExpressionSchema,
   GetInstructionsSchema,
   GetQuerySchema,
@@ -19,6 +17,8 @@ import type {
   QuerySchema,
   QuerySchemaSchema,
   QueryTypeEnum,
+  RemoveInstructionsSchema,
+  RemoveQuerySchema,
   SetInstructionsSchema,
   SetQuerySchema,
   WithInstructionSchema,
@@ -38,8 +38,8 @@ export type AddQuery = z.infer<typeof AddQuerySchema>;
 export type AddInstructions = z.infer<typeof AddInstructionsSchema>;
 
 // Delete Queries.
-export type DeleteQuery = z.infer<typeof DeleteQuerySchema>;
-export type DeleteInstructions = z.infer<typeof DeleteInstructionsSchema>;
+export type RemoveQuery = z.infer<typeof RemoveQuerySchema>;
+export type RemoveInstructions = z.infer<typeof RemoveInstructionsSchema>;
 
 // Count Queries.
 export type CountQuery = z.infer<typeof CountQuerySchema>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -93,7 +93,7 @@ export const compileQueryInput = (
       statement += 'INSERT INTO ';
       break;
 
-    case 'delete':
+    case 'remove':
       statement += 'DELETE FROM ';
       break;
 
@@ -154,7 +154,7 @@ export const compileQueryInput = (
 
   const conditions: Array<string> = [];
 
-  // Queries of type "get", "set", "delete", or "count" all support filtering records,
+  // Queries of type "get", "set", "remove", or "count" all support filtering records,
   // but those of type "add" do not.
   if (queryType !== 'add' && instructions && Object.hasOwn(instructions, 'with')) {
     const withStatement = handleWith(
@@ -249,7 +249,7 @@ export const compileQueryInput = (
 
   // For queries that modify records, we want to make sure that the modified record is
   // returned after the modification has been performed.
-  if (['add', 'set', 'delete'].includes(queryType) && returning) {
+  if (['add', 'set', 'remove'].includes(queryType) && returning) {
     statement += 'RETURNING * ';
   }
 

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -59,13 +59,13 @@ export const transformMetaQuery = (
     };
 
     addModelQueries(models, dependencyStatements, {
-      queryType: 'delete',
+      queryType: 'remove',
       queryModel: 'model',
       queryInstructions: instructions,
     });
 
     return {
-      delete: {
+      remove: {
         model: instructions,
       },
     };
@@ -153,13 +153,13 @@ export const transformMetaQuery = (
     };
 
     addModelQueries(models, dependencyStatements, {
-      queryType: 'delete',
+      queryType: 'remove',
       queryModel: type,
       queryInstructions: instructions,
     });
 
     return {
-      delete: {
+      remove: {
         [type]: instructions,
       },
     };

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -643,7 +643,7 @@ type QueryInstructionTypeClean = Exclude<
 const mappedInstructions: Partial<Record<QueryType, QueryInstructionTypeClean>> = {
   add: 'to',
   set: 'with',
-  delete: 'with',
+  remove: 'with',
 };
 
 /** A list of all RONIN data types and their respective column types in SQLite. */
@@ -733,7 +733,7 @@ export const addModelQueries = (
   const { queryType, queryModel, queryInstructions } = queryDetails;
 
   // Only continue if the query is a write query.
-  if (!['add', 'set', 'delete'].includes(queryType)) return;
+  if (!['add', 'set', 'remove'].includes(queryType)) return;
 
   // Only continue if the query addresses system models.
   if (!SYSTEM_MODEL_SLUGS.includes(queryModel)) return;
@@ -762,7 +762,7 @@ export const addModelQueries = (
       break;
     }
 
-    case 'delete': {
+    case 'remove': {
       if (kind === 'models' || kind === 'indexes' || kind === 'triggers') {
         tableAction = 'DROP';
       }
@@ -964,7 +964,7 @@ export const addModelQueries = (
 
       // Update the existing model in the list of models.
       Object.assign(targetModel as Model, queryInstructions.to);
-    } else if (queryType === 'delete') {
+    } else if (queryType === 'remove') {
       // Remove the model from the list of models.
       models.splice(models.indexOf(targetModel as Model), 1);
 
@@ -994,7 +994,7 @@ export const addModelQueries = (
           params: [],
         });
       }
-    } else if (queryType === 'delete') {
+    } else if (queryType === 'remove') {
       dependencyStatements.push({
         statement: `${statement} DROP COLUMN "${slug}"`,
         params: [],

--- a/src/validators/query.ts
+++ b/src/validators/query.ts
@@ -2,7 +2,7 @@ import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 import { z } from 'zod';
 
 // Query Types.
-export const QueryTypeEnum = z.enum(['get', 'set', 'add', 'delete', 'count']);
+export const QueryTypeEnum = z.enum(['get', 'set', 'add', 'remove', 'count']);
 
 // Model Query Types.
 export const ModelQueryTypeEnum = z.enum(['create', 'alter', 'drop']);
@@ -247,11 +247,11 @@ export const AddQuerySchema = z.object({
 });
 
 // Drop Queries.
-export const DeleteInstructionsSchema = InstructionsSchema.partial().omit({
+export const RemoveInstructionsSchema = InstructionsSchema.partial().omit({
   to: true,
 });
-export const DeleteQuerySchema = z.object({
-  delete: z.record(z.string(), DeleteInstructionsSchema),
+export const RemoveQuerySchema = z.object({
+  remove: z.record(z.string(), RemoveInstructionsSchema),
 });
 
 // Count Queries.
@@ -267,7 +267,7 @@ export const CombinedInstructionsSchema = z.union([
   SetInstructionsSchema,
   CountInstructionsSchema,
   AddInstructionsSchema,
-  DeleteInstructionsSchema,
+  RemoveInstructionsSchema,
   GetInstructionsSchema,
 ]);
 export const InstructionSchema = z.enum([
@@ -291,7 +291,7 @@ export const QuerySchema = z
     [QueryTypeEnum.Enum.get]: z.record(z.string(), GetInstructionsSchema.nullable()),
     [QueryTypeEnum.Enum.set]: z.record(z.string(), SetInstructionsSchema),
     [QueryTypeEnum.Enum.add]: z.record(z.string(), AddInstructionsSchema),
-    [QueryTypeEnum.Enum.delete]: z.record(z.string(), DeleteInstructionsSchema),
+    [QueryTypeEnum.Enum.remove]: z.record(z.string(), RemoveInstructionsSchema),
     [QueryTypeEnum.Enum.count]: z.record(z.string(), CountInstructionsSchema.nullable()),
 
     [ModelQueryTypeEnum.Enum.create]: z.union([

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -278,7 +278,7 @@ test('set single record to new many-cardinality link field (add)', () => {
   ]);
 });
 
-test('set single record to new many-cardinality link field (delete)', () => {
+test('set single record to new many-cardinality link field (remove)', () => {
   const queries: Array<Query> = [
     {
       set: {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1150,10 +1150,10 @@ test('create new per-record trigger for creating records', () => {
   ]);
 });
 
-test('create new per-record trigger for deleting records', () => {
+test('create new per-record trigger for removing records', () => {
   const effectQueries = [
     {
-      delete: {
+      remove: {
         members: {
           with: {
             account: {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -28,10 +28,10 @@ test('get single record', () => {
   ]);
 });
 
-test('delete single record', () => {
+test('remove single record', () => {
   const queries: Array<Query> = [
     {
-      delete: {
+      remove: {
         account: {
           with: {
             handle: 'elaine',


### PR DESCRIPTION
Since `delete` is a [reserved keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar) in JavaScript, it can't be used a standalone variable.