### PR TITLE
Properly serialize statement params

### DIFF
--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -43,7 +43,11 @@ export const prepareStatementValue = (
   // If no list of statement values is available, that means we should inline the value,
   // which is desired in cases where there is no risk of SQL injection and where the
   // values must be plainly visible for manual human inspection.
-  if (!statementParams) return JSON.stringify(value);
+  if (!statementParams) {
+    const valueString =
+      typeof value === 'object' ? JSON.stringify(value) : value!.toString();
+    return `'${valueString}'`;
+  }
 
   let formattedValue = value;
 

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -5,9 +5,12 @@ import type { Query } from '@/src/types/query';
 test('inline statement values', () => {
   const queries: Array<Query> = [
     {
-      get: {
+      add: {
         account: {
-          with: { handle: 'elaine' },
+          to: {
+            handle: 'elaine',
+            emails: ['test@site.co', 'elaine@site.com'],
+          },
         },
       },
     },
@@ -21,6 +24,10 @@ test('inline statement values', () => {
           slug: 'handle',
           type: 'string',
         },
+        {
+          slug: 'emails',
+          type: 'json',
+        },
       ],
     },
   ];
@@ -29,11 +36,8 @@ test('inline statement values', () => {
     inlineParams: true,
   });
 
-  expect(statements).toEqual([
-    {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" = "elaine") LIMIT 1',
-      params: [],
-      returning: true,
-    },
-  ]);
+  expect(statements[0].statement).toStartWith(
+    `INSERT INTO "accounts" ("handle", "emails", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ('elaine', '["test@site.co","elaine@site.com"]'`,
+  );
+  expect(statements[0].params).toEqual([]);
 });


### PR DESCRIPTION
Statement params should use single quotes, not double quotes! Identifiers should use double quotes.