### PR TITLE
Use a single table for database schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,16 +36,19 @@ export const compileQueries = (
   const mainStatements: Array<Statement> = [];
 
   for (const query of queries) {
+    const statementValues = options?.inlineParams ? null : [];
+
     const transformedQuery = transformMetaQuery(
       modelListWithPresets,
       dependencyStatements,
+      statementValues,
       query,
     );
 
     const result = compileQueryInput(
       transformedQuery,
       modelListWithPresets,
-      options?.inlineParams ? null : [],
+      statementValues,
     );
 
     // Every query can only produce one main statement (which can return output), but

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -114,7 +114,7 @@ export const transformMetaQuery = (
       const pluralType = PLURAL_MODEL_ENTITIES[type];
 
       const item = query.alter.create[type] as Partial<ModelIndex>;
-      const completeItem = { slug: item.slug || `${type}_slug`, ...item };
+      const completeItem = { slug: item.slug || `${type}Slug`, ...item };
 
       const instructions = {
         to: {

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -10,7 +10,7 @@ import {
 import { prepareStatementValue } from '@/src/utils/statement';
 
 // Keeping these hardcoded instead of using `pluralize` is faster.
-const PLURAL_MODEL_ENTITIES: Record<ModelEntity, string> = {
+export const PLURAL_MODEL_ENTITIES: Record<ModelEntity, string> = {
   field: 'fields',
   index: 'indexes',
   trigger: 'triggers',

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -9,6 +9,7 @@ import {
 } from '@/src/utils/model';
 import { prepareStatementValue } from '@/src/utils/statement';
 
+// Keeping these hardcoded instead of using `pluralize` is faster.
 const PLURAL_MODEL_ENTITIES: Record<ModelEntity, string> = {
   field: 'fields',
   index: 'indexes',

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -25,6 +25,7 @@ import {
   type splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
+import { PLURAL_MODEL_ENTITIES } from '@/src/utils/meta';
 import { getSymbol, parseFieldExpression } from '@/src/utils/statement';
 import title from 'title';
 
@@ -775,7 +776,7 @@ export const addModelQueries = (
       if (fields) {
         if (action !== 'UPDATE') {
           throw new RoninError({
-            message: `When ${queryTypeReadable} ${pluralize(queryModel)}, targeting specific fields requires the \`UPDATE\` action.`,
+            message: `When ${queryTypeReadable} ${PLURAL_MODEL_ENTITIES[queryModel]}, targeting specific fields requires the \`UPDATE\` action.`,
             code: 'INVALID_MODEL_VALUE',
             fields: ['action'],
           });

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -346,7 +346,7 @@ export const SYSTEM_FIELDS: Array<ModelField> = [
 ];
 
 /** These models are required by the system and are automatically made available. */
-const SYSTEM_MODELS: Array<PublicModel> = [
+const SYSTEM_MODELS: Array<PartialModel> = [
   {
     slug: 'model',
 
@@ -354,6 +354,9 @@ const SYSTEM_MODELS: Array<PublicModel> = [
       name: 'name',
       slug: 'slug',
     },
+
+    // This name mimics the `sqlite_schema` table in SQLite.
+    table: 'ronin_schema',
 
     fields: [
       { slug: 'name', type: 'string' },

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -368,10 +368,13 @@ const SYSTEM_MODELS: Array<PublicModel> = [
       { slug: 'identifiers.name', type: 'string' },
       { slug: 'identifiers.slug', type: 'string' },
 
-      { slug: 'fields', type: 'json' },
-      { slug: 'indexes', type: 'json' },
-      { slug: 'triggers', type: 'json' },
-      { slug: 'presets', type: 'json' },
+      // Providing an empty object as a default value allows us to use `json_insert`
+      // without needing to fall back to an empty object in the insertion statement,
+      // which makes the statement shorter.
+      { slug: 'fields', type: 'json', defaultValue: '{}' },
+      { slug: 'indexes', type: 'json', defaultValue: '{}' },
+      { slug: 'triggers', type: 'json', defaultValue: '{}' },
+      { slug: 'presets', type: 'json', defaultValue: '{}' },
     ],
   },
 ];

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -346,7 +346,7 @@ export const SYSTEM_FIELDS: Array<ModelField> = [
 ];
 
 /** These models are required by the system and are automatically made available. */
-const SYSTEM_MODELS: Array<Model> = [
+const SYSTEM_MODELS: Array<PublicModel> = [
   {
     slug: 'model',
 
@@ -374,7 +374,7 @@ const SYSTEM_MODELS: Array<Model> = [
       { slug: 'presets', type: 'json' },
     ],
   },
-].map((model) => addDefaultModelFields(model as PublicModel, true));
+];
 
 /**
  * Extends a list of models with automatically generated models that make writing

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -27,7 +27,8 @@ import { getFieldFromModel, getModelBySlug } from '@/src/utils/model';
 /**
  * Inserts a value into the list of statement values and returns a placeholder for it.
  *
- * @param statementParams - A list of values to be inserted into the final statements.
+ * @param statementParams - A collection of values that will automatically be
+ * inserted into the query by SQLite.
  * @param value - The value that should be prepared for insertion.
  *
  * @returns A placeholder for the inserted value.
@@ -110,7 +111,8 @@ export const parseFieldExpression = (
  *
  * @param models - A list of models.
  * @param model - The specific model being addressed in the query.
- * @param statementParams - A list of values to be inserted into the final statements.
+ * @param statementParams - A collection of values that will automatically be
+ * inserted into the query by SQLite.
  * @param instructionName - The name of the instruction that is being processed.
  * @param value - The value that the selected field should be compared with.
  * @param options - Additional options for customizing the behavior of the function.
@@ -179,7 +181,8 @@ export const composeFieldValues = (
  *
  * @param models - A list of models.
  * @param model - The specific model being addressed in the query.
- * @param statementParams - A list of values to be inserted into the final statements.
+ * @param statementParams - A collection of values that will automatically be
+ * inserted into the query by SQLite.
  * @param instructionName - The name of the instruction that is being processed.
  * @param value - The value that the selected field should be compared with.
  * @param options - Additional options for customizing the behavior of the function.

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -322,6 +322,7 @@ test('query a model that was just dropped', () => {
 
 test('create new field', () => {
   const field: ModelField = {
+    slug: 'email',
     type: 'string',
   };
 
@@ -346,13 +347,13 @@ test('create new field', () => {
 
   expect(statements).toEqual([
     {
-      statement: 'ALTER TABLE "accounts" ADD COLUMN "fieldSlug" TEXT',
+      statement: 'ALTER TABLE "accounts" ADD COLUMN "email" TEXT',
       params: [],
     },
     {
       statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.fieldSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'fieldSlug', ...field }),
+        JSON.stringify(field),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -415,15 +415,17 @@ test('create new field with options', () => {
 // Ensure that, if the `slug` of a field changes during a model update, an `ALTER TABLE`
 // statement is generated for it.
 test('update existing field (slug)', () => {
+  const newFieldDetails = {
+    slug: 'emailAddress',
+  };
+
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         alter: {
           field: 'email',
-          to: {
-            slug: 'emailAddress',
-          },
+          to: newFieldDetails,
         },
       },
     },
@@ -443,13 +445,11 @@ test('update existing field (slug)', () => {
       params: [],
     },
     {
-      statement:
-        'UPDATE "fields" SET "slug" = ?1, "ronin.updatedAt" = ?2 WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?3) LIMIT 1) AND "slug" = ?4) RETURNING *',
+      statement: `UPDATE "models" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        'emailAddress',
+        JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'email',
       ],
       returning: true,
     },
@@ -459,15 +459,17 @@ test('update existing field (slug)', () => {
 // Ensure that, if the `slug` of a field does not change during a model update, no
 // unnecessary `ALTER TABLE` statement is generated for it.
 test('update existing field (name)', () => {
+  const newFieldDetails = {
+    name: 'Email Address',
+  };
+
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         alter: {
           field: 'email',
-          to: {
-            name: 'Email Address',
-          },
+          to: newFieldDetails,
         },
       },
     },
@@ -483,13 +485,11 @@ test('update existing field (name)', () => {
 
   expect(statements).toEqual([
     {
-      statement:
-        'UPDATE "fields" SET "name" = ?1, "ronin.updatedAt" = ?2 WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?3) LIMIT 1) AND "slug" = ?4) RETURNING *',
+      statement: `UPDATE "models" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        'Email Address',
+        JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'email',
       ],
       returning: true,
     },
@@ -1331,10 +1331,12 @@ test('create new preset', () => {
 });
 
 test('update existing preset', () => {
-  const instructions = {
-    with: {
-      email: {
-        endingWith: '@site.co',
+  const newPresetDetails = {
+    instructions: {
+      with: {
+        email: {
+          endingWith: '@site.co',
+        },
       },
     },
   };
@@ -1345,7 +1347,7 @@ test('update existing preset', () => {
         model: 'account',
         alter: {
           preset: 'company_employees',
-          to: { instructions },
+          to: newPresetDetails,
         },
       },
     },
@@ -1362,13 +1364,11 @@ test('update existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement:
-        'UPDATE "presets" SET "instructions" = ?1, "ronin.updatedAt" = ?2 WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?3) LIMIT 1) AND "slug" = ?4) RETURNING *',
+      statement: `UPDATE "models" SET "presets" = json_patch("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify(instructions),
+        JSON.stringify(newPresetDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'company_employees',
       ],
       returning: true,
     },

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -564,9 +564,9 @@ test('create new index', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'index_slug', ...index }),
+        JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -616,9 +616,9 @@ test('create new index with filter', () => {
       params: ['@site.co'],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'index_slug', ...index }),
+        JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -671,9 +671,9 @@ test('create new index with field expressions', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'index_slug', ...index }),
+        JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -719,9 +719,9 @@ test('create new index with ordered and collated fields', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'index_slug', ...index }),
+        JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -766,9 +766,9 @@ test('create new unique index', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'index_slug', ...index }),
+        JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -783,7 +783,7 @@ test('drop existing index', () => {
       alter: {
         model: 'account',
         drop: {
-          index: 'index_slug',
+          index: 'indexSlug',
         },
       },
     },
@@ -805,7 +805,7 @@ test('drop existing index', () => {
     {
       statement:
         'DELETE FROM "indexes" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['account', 'index_slug'],
+      params: ['account', 'indexSlug'],
       returning: true,
     },
   ]);
@@ -863,9 +863,9 @@ test('create new trigger for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -932,9 +932,9 @@ test('create new trigger for creating records with targeted fields', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -1012,9 +1012,9 @@ test('create new trigger for creating records with multiple effects', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],
@@ -1090,9 +1090,9 @@ test('create new per-record trigger for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
       ],
@@ -1160,9 +1160,9 @@ test('create new per-record trigger for removing records', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
       ],
@@ -1242,9 +1242,9 @@ test('create new per-record trigger with filters for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
       ],
@@ -1259,7 +1259,7 @@ test('drop existing trigger', () => {
       alter: {
         model: 'team',
         drop: {
-          trigger: 'trigger_slug',
+          trigger: 'triggerSlug',
         },
       },
     },
@@ -1281,7 +1281,7 @@ test('drop existing trigger', () => {
     {
       statement:
         'DELETE FROM "triggers" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['team', 'trigger_slug'],
+      params: ['team', 'triggerSlug'],
       returning: true,
     },
   ]);

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -351,7 +351,7 @@ test('create new field', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.fieldSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(field),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -415,7 +415,7 @@ test('create new field with options', () => {
 // Ensure that, if the `slug` of a field changes during a model update, an `ALTER TABLE`
 // statement is generated for it.
 test('update existing field (slug)', () => {
-  const newFieldDetails = {
+  const newFieldDetails: Partial<ModelField> = {
     slug: 'emailAddress',
   };
 
@@ -459,7 +459,7 @@ test('update existing field (slug)', () => {
 // Ensure that, if the `slug` of a field does not change during a model update, no
 // unnecessary `ALTER TABLE` statement is generated for it.
 test('update existing field (name)', () => {
-  const newFieldDetails = {
+  const newFieldDetails: Partial<ModelField> = {
     name: 'Email Address',
   };
 
@@ -1331,7 +1331,7 @@ test('create new preset', () => {
 });
 
 test('update existing preset', () => {
-  const newPresetDetails = {
+  const newPresetDetails: Partial<ModelPreset> = {
     instructions: {
       with: {
         email: {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { type Model, compileQueries } from '@/src/index';
 import type { Query } from '@/src/types/query';
 
+import type { ModelPreset } from '@/src/types/model';
 import {
   RECORD_TIMESTAMP_REGEX,
   RONIN_MODEL_SYMBOLS,
@@ -9,6 +10,7 @@ import {
 } from '@/src/utils/helpers';
 import { RECORD_ID_REGEX } from '@/src/utils/helpers';
 import { SYSTEM_FIELDS } from '@/src/utils/model';
+import type { ModelField, ModelIndex, ModelTrigger } from '../dist';
 
 test('create new model', () => {
   const fields = [
@@ -319,14 +321,16 @@ test('query a model that was just dropped', () => {
 });
 
 test('create new field', () => {
+  const field: ModelField = {
+    slug: 'email',
+  };
+
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          field: {
-            slug: 'email',
-          },
+          field,
         },
       },
     },
@@ -346,15 +350,11 @@ test('create new field', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "fields" ("model", "slug", "type", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6) RETURNING *',
+      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify(field),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'email',
-        'string',
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -362,19 +362,21 @@ test('create new field', () => {
 });
 
 test('create new field with options', () => {
+  const field: ModelField = {
+    slug: 'account',
+    type: 'link',
+    target: 'account',
+    actions: {
+      onDelete: 'CASCADE',
+    },
+  };
+
   const queries: Array<Query> = [
     {
       alter: {
         model: 'member',
         create: {
-          field: {
-            slug: 'account',
-            type: 'link',
-            target: 'account',
-            actions: {
-              onDelete: 'CASCADE',
-            },
-          },
+          field,
         },
       },
     },
@@ -398,17 +400,11 @@ test('create new field with options', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "fields" ("model", "slug", "type", "target", "actions.onDelete", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
+      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.account', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify(field),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'member',
-        'account',
-        'link',
-        'account',
-        'CASCADE',
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -534,18 +530,20 @@ test('drop existing field', () => {
 });
 
 test('create new index', () => {
-  const fields = [
-    {
-      slug: 'email',
-    },
-  ];
+  const index: ModelIndex = {
+    fields: [
+      {
+        slug: 'email',
+      },
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          index: { fields },
+          index,
         },
       },
     },
@@ -566,15 +564,11 @@ test('create new index', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "indexes" ("model", "slug", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6) RETURNING *',
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'index_slug', ...index }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'index_slug',
-        JSON.stringify(fields),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -582,15 +576,16 @@ test('create new index', () => {
 });
 
 test('create new index with filter', () => {
-  const fields = [
-    {
-      slug: 'email',
-    },
-  ];
-
-  const filterInstruction = {
-    email: {
-      endingWith: '@site.co',
+  const index: ModelIndex = {
+    fields: [
+      {
+        slug: 'email',
+      },
+    ],
+    filter: {
+      email: {
+        endingWith: '@site.co',
+      },
     },
   };
 
@@ -599,10 +594,7 @@ test('create new index with filter', () => {
       alter: {
         model: 'account',
         create: {
-          index: {
-            fields,
-            filter: filterInstruction,
-          },
+          index,
         },
       },
     },
@@ -624,16 +616,11 @@ test('create new index with filter', () => {
       params: ['@site.co'],
     },
     {
-      statement:
-        'INSERT INTO "indexes" ("model", "slug", "fields", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7) RETURNING *',
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'index_slug', ...index }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'index_slug',
-        JSON.stringify(fields),
-        JSON.stringify(filterInstruction),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -641,18 +628,20 @@ test('create new index with filter', () => {
 });
 
 test('create new index with field expressions', () => {
-  const fields = [
-    {
-      expression: `LOWER(${RONIN_MODEL_SYMBOLS.FIELD}firstName || ' ' || ${RONIN_MODEL_SYMBOLS.FIELD}lastName)`,
-    },
-  ];
+  const index: ModelIndex = {
+    fields: [
+      {
+        expression: `LOWER(${RONIN_MODEL_SYMBOLS.FIELD}firstName || ' ' || ${RONIN_MODEL_SYMBOLS.FIELD}lastName)`,
+      },
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          index: { fields },
+          index,
         },
       },
     },
@@ -682,15 +671,11 @@ test('create new index with field expressions', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "indexes" ("model", "slug", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6) RETURNING *',
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'index_slug', ...index }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'index_slug',
-        JSON.stringify(fields),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -698,20 +683,22 @@ test('create new index with field expressions', () => {
 });
 
 test('create new index with ordered and collated fields', () => {
-  const fields = [
-    {
-      slug: 'email',
-      order: 'ASC',
-      collation: 'NOCASE',
-    },
-  ];
+  const index: ModelIndex = {
+    fields: [
+      {
+        slug: 'email',
+        order: 'ASC',
+        collation: 'NOCASE',
+      },
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          index: { fields },
+          index,
         },
       },
     },
@@ -732,15 +719,11 @@ test('create new index with ordered and collated fields', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "indexes" ("model", "slug", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6) RETURNING *',
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'index_slug', ...index }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'index_slug',
-        JSON.stringify(fields),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -748,21 +731,21 @@ test('create new index with ordered and collated fields', () => {
 });
 
 test('create new unique index', () => {
-  const fields = [
-    {
-      slug: 'email',
-    },
-  ];
+  const index: ModelIndex = {
+    fields: [
+      {
+        slug: 'email',
+      },
+    ],
+    unique: true,
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          index: {
-            fields,
-            unique: true,
-          },
+          index,
         },
       },
     },
@@ -783,16 +766,11 @@ test('create new unique index', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "indexes" ("model", "slug", "fields", "unique", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7) RETURNING *',
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.index_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'index_slug', ...index }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'index_slug',
-        JSON.stringify(fields),
-        1,
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -834,28 +812,28 @@ test('drop existing index', () => {
 });
 
 test('create new trigger for creating records', () => {
-  const effectQueries = [
-    {
-      add: {
-        signup: {
-          to: {
-            year: 2000,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'INSERT',
+    effects: [
+      {
+        add: {
+          signup: {
+            to: {
+              year: 2000,
+            },
           },
         },
       },
-    },
-  ];
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'INSERT',
-            effects: effectQueries,
-          },
+          trigger,
         },
       },
     },
@@ -885,17 +863,11 @@ test('create new trigger for creating records', () => {
       ],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'trigger_slug',
-        'AFTER',
-        'INSERT',
-        JSON.stringify(effectQueries),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -903,35 +875,33 @@ test('create new trigger for creating records', () => {
 });
 
 test('create new trigger for creating records with targeted fields', () => {
-  const effectQueries = [
-    {
-      add: {
-        signup: {
-          to: {
-            year: 2000,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'UPDATE',
+    effects: [
+      {
+        add: {
+          signup: {
+            to: {
+              year: 2000,
+            },
           },
         },
       },
-    },
-  ];
-
-  const fields = [
-    {
-      slug: 'email',
-    },
-  ];
+    ],
+    fields: [
+      {
+        slug: 'email',
+      },
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'UPDATE',
-            effects: effectQueries,
-            fields,
-          },
+          trigger,
         },
       },
     },
@@ -962,18 +932,11 @@ test('create new trigger for creating records with targeted fields', () => {
       ],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "fields", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'trigger_slug',
-        'AFTER',
-        'UPDATE',
-        JSON.stringify(effectQueries),
-        JSON.stringify(fields),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -981,37 +944,37 @@ test('create new trigger for creating records with targeted fields', () => {
 });
 
 test('create new trigger for creating records with multiple effects', () => {
-  const effectQueries = [
-    {
-      add: {
-        signup: {
-          to: {
-            year: 2000,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'INSERT',
+    effects: [
+      {
+        add: {
+          signup: {
+            to: {
+              year: 2000,
+            },
           },
         },
       },
-    },
-    {
-      add: {
-        candidate: {
-          to: {
-            year: 2020,
+      {
+        add: {
+          candidate: {
+            to: {
+              year: 2020,
+            },
           },
         },
       },
-    },
-  ];
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'account',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'INSERT',
-            effects: effectQueries,
-          },
+          trigger,
         },
       },
     },
@@ -1049,17 +1012,11 @@ test('create new trigger for creating records with multiple effects', () => {
       ],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'trigger_slug',
-        'AFTER',
-        'INSERT',
-        JSON.stringify(effectQueries),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -1067,32 +1024,32 @@ test('create new trigger for creating records with multiple effects', () => {
 });
 
 test('create new per-record trigger for creating records', () => {
-  const effectQueries = [
-    {
-      add: {
-        member: {
-          to: {
-            account: {
-              [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'INSERT',
+    effects: [
+      {
+        add: {
+          member: {
+            to: {
+              account: {
+                [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+              },
+              role: 'owner',
+              pending: false,
             },
-            role: 'owner',
-            pending: false,
           },
         },
       },
-    },
-  ];
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'team',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'INSERT',
-            effects: effectQueries,
-          },
+          trigger,
         },
       },
     },
@@ -1133,17 +1090,11 @@ test('create new per-record trigger for creating records', () => {
       ],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
-        'trigger_slug',
-        'AFTER',
-        'INSERT',
-        JSON.stringify(effectQueries),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -1151,30 +1102,30 @@ test('create new per-record trigger for creating records', () => {
 });
 
 test('create new per-record trigger for removing records', () => {
-  const effectQueries = [
-    {
-      remove: {
-        members: {
-          with: {
-            account: {
-              [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_OLD}createdBy`,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'DELETE',
+    effects: [
+      {
+        remove: {
+          members: {
+            with: {
+              account: {
+                [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_OLD}createdBy`,
+              },
             },
           },
         },
       },
-    },
-  ];
+    ],
+  };
 
   const queries: Array<Query> = [
     {
       alter: {
         model: 'team',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'DELETE',
-            effects: effectQueries,
-          },
+          trigger,
         },
       },
     },
@@ -1209,17 +1160,11 @@ test('create new per-record trigger for removing records', () => {
       params: [],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
-        'trigger_slug',
-        'AFTER',
-        'DELETE',
-        JSON.stringify(effectQueries),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -1227,25 +1172,28 @@ test('create new per-record trigger for removing records', () => {
 });
 
 test('create new per-record trigger with filters for creating records', () => {
-  const effectQueries = [
-    {
-      add: {
-        member: {
-          to: {
-            account: {
-              [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+  const trigger: ModelTrigger = {
+    when: 'AFTER',
+    action: 'INSERT',
+    effects: [
+      {
+        add: {
+          member: {
+            to: {
+              account: {
+                [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+              },
+              role: 'owner',
+              pending: false,
             },
-            role: 'owner',
-            pending: false,
           },
         },
       },
-    },
-  ];
-
-  const filterInstruction = {
-    handle: {
-      endingWith: '_hidden',
+    ],
+    filter: {
+      handle: {
+        endingWith: '_hidden',
+      },
     },
   };
 
@@ -1254,12 +1202,7 @@ test('create new per-record trigger with filters for creating records', () => {
       alter: {
         model: 'team',
         create: {
-          trigger: {
-            when: 'AFTER',
-            action: 'INSERT',
-            effects: effectQueries,
-            filter: filterInstruction,
-          },
+          trigger,
         },
       },
     },
@@ -1299,18 +1242,11 @@ test('create new per-record trigger with filters for creating records', () => {
       ],
     },
     {
-      statement:
-        'INSERT INTO "triggers" ("model", "slug", "when", "action", "effects", "filter", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) RETURNING *',
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.trigger_slug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify({ slug: 'trigger_slug', ...trigger }),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'team',
-        'trigger_slug',
-        'AFTER',
-        'INSERT',
-        JSON.stringify(effectQueries),
-        JSON.stringify(filterInstruction),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },
@@ -1352,10 +1288,13 @@ test('drop existing trigger', () => {
 });
 
 test('create new preset', () => {
-  const instructions = {
-    with: {
-      email: {
-        endingWith: '@company.co',
+  const preset: ModelPreset = {
+    slug: 'company_employees',
+    instructions: {
+      with: {
+        email: {
+          endingWith: '@company.co',
+        },
       },
     },
   };
@@ -1365,10 +1304,7 @@ test('create new preset', () => {
       alter: {
         model: 'account',
         create: {
-          preset: {
-            slug: 'company_employees',
-            instructions,
-          },
+          preset,
         },
       },
     },
@@ -1385,15 +1321,11 @@ test('create new preset', () => {
 
   expect(statements).toEqual([
     {
-      statement:
-        'INSERT INTO "presets" ("model", "slug", "instructions", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ((SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1), ?2, ?3, ?4, ?5, ?6) RETURNING *',
+      statement: `UPDATE "models" SET "presets" = json_insert("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
+        JSON.stringify(preset),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
-        'company_employees',
-        JSON.stringify(instructions),
-        expect.stringMatching(RECORD_ID_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       ],
       returning: true,
     },

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -322,7 +322,7 @@ test('query a model that was just dropped', () => {
 
 test('create new field', () => {
   const field: ModelField = {
-    slug: 'email',
+    type: 'string',
   };
 
   const queries: Array<Query> = [
@@ -346,13 +346,13 @@ test('create new field', () => {
 
   expect(statements).toEqual([
     {
-      statement: 'ALTER TABLE "accounts" ADD COLUMN "email" TEXT',
+      statement: 'ALTER TABLE "accounts" ADD COLUMN "fieldSlug" TEXT',
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.fieldSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
-        JSON.stringify(field),
+        JSON.stringify({ slug: 'fieldSlug', ...field }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         'account',
       ],

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -522,9 +522,8 @@ test('drop existing field', () => {
       params: [],
     },
     {
-      statement:
-        'DELETE FROM "fields" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['account', 'email'],
+      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
   ]);
@@ -804,9 +803,8 @@ test('drop existing index', () => {
       params: [],
     },
     {
-      statement:
-        'DELETE FROM "indexes" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['account', 'indexSlug'],
+      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
   ]);
@@ -1280,9 +1278,8 @@ test('drop existing trigger', () => {
       params: [],
     },
     {
-      statement:
-        'DELETE FROM "triggers" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['team', 'triggerSlug'],
+      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'team'],
       returning: true,
     },
   ]);
@@ -1400,9 +1397,8 @@ test('drop existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement:
-        'DELETE FROM "presets" WHERE ("model" = (SELECT "id" FROM "models" WHERE ("slug" = ?1) LIMIT 1) AND "slug" = ?2) RETURNING *',
-      params: ['account', 'company_employees'],
+      statement: `UPDATE "models" SET "presets" = json_insert("presets", '$.company_employees'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
   ]);

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -65,7 +65,7 @@ test('create new model', () => {
     },
     {
       statement:
-        'INSERT INTO "models" ("slug", "fields", "pluralSlug", "name", "pluralName", "idPrefix", "table", "identifiers.name", "identifiers.slug", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) RETURNING *',
+        'INSERT INTO "ronin_schema" ("slug", "fields", "pluralSlug", "name", "pluralName", "idPrefix", "table", "identifiers.name", "identifiers.slug", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) RETURNING *',
       params: [
         'account',
         JSON.stringify([...SYSTEM_FIELDS, ...fields]),
@@ -147,7 +147,7 @@ test('update existing model (slug)', () => {
     },
     {
       statement:
-        'UPDATE "models" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = ?7 WHERE ("slug" = ?8) RETURNING *',
+        'UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = ?7 WHERE ("slug" = ?8) RETURNING *',
       params: [
         'user',
         'users',
@@ -188,7 +188,7 @@ test('update existing model (plural name)', () => {
   expect(statements).toEqual([
     {
       statement:
-        'UPDATE "models" SET "pluralName" = ?1, "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *',
+        'UPDATE "ronin_schema" SET "pluralName" = ?1, "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *',
       params: ['Signups', expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
@@ -218,7 +218,7 @@ test('drop existing model', () => {
       params: [],
     },
     {
-      statement: 'DELETE FROM "models" WHERE ("slug" = ?1) RETURNING *',
+      statement: 'DELETE FROM "ronin_schema" WHERE ("slug" = ?1) RETURNING *',
       params: ['account'],
       returning: true,
     },
@@ -351,7 +351,7 @@ test('create new field', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(field),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -401,7 +401,7 @@ test('create new field with options', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.account', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.account', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(field),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -445,7 +445,7 @@ test('update existing field (slug)', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -485,7 +485,7 @@ test('update existing field (name)', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "models" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -522,7 +522,7 @@ test('drop existing field', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "fields" = json_insert("fields", '$.email'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.email'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
       params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
@@ -564,7 +564,7 @@ test('create new index', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -616,7 +616,7 @@ test('create new index with filter', () => {
       params: ['@site.co'],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -671,7 +671,7 @@ test('create new index with field expressions', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -719,7 +719,7 @@ test('create new index with ordered and collated fields', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -766,7 +766,7 @@ test('create new unique index', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'indexSlug', ...index }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -803,7 +803,7 @@ test('drop existing index', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "indexes" = json_insert("indexes", '$.indexSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
       params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },
@@ -862,7 +862,7 @@ test('create new trigger for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -931,7 +931,7 @@ test('create new trigger for creating records with targeted fields', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1011,7 +1011,7 @@ test('create new trigger for creating records with multiple effects', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1089,7 +1089,7 @@ test('create new per-record trigger for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1159,7 +1159,7 @@ test('create new per-record trigger for removing records', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1241,7 +1241,7 @@ test('create new per-record trigger with filters for creating records', () => {
       ],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify({ slug: 'triggerSlug', ...trigger }),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1278,7 +1278,7 @@ test('drop existing trigger', () => {
       params: [],
     },
     {
-      statement: `UPDATE "models" SET "triggers" = json_insert("triggers", '$.triggerSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
       params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'team'],
       returning: true,
     },
@@ -1319,7 +1319,7 @@ test('create new preset', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "models" SET "presets" = json_insert("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "presets" = json_insert("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(preset),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1364,7 +1364,7 @@ test('update existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "models" SET "presets" = json_patch("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "presets" = json_patch("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newPresetDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1397,7 +1397,7 @@ test('drop existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "models" SET "presets" = json_insert("presets", '$.company_employees'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "presets" = json_insert("presets", '$.company_employees'), "ronin.updatedAt" = ?1 WHERE ("slug" = ?2) RETURNING *`,
       params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'account'],
       returning: true,
     },


### PR DESCRIPTION
This change ensures that only a single table (`ronin_schema`) is used to store the entire database schema.