### PR TITLE
Correctly patch individual model entities

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -962,11 +962,13 @@ export const transformMetaQuery = (
   }
 
   const pluralType = PLURAL_MODEL_ENTITIES[entity];
+  const field = `${RONIN_MODEL_SYMBOLS.FIELD}${pluralType}`;
 
-  const jsonAction =
-    action === 'create' ? 'insert' : action === 'alter' ? 'patch' : 'remove';
+  let json =
+    action === 'alter'
+      ? `json_patch(json_extract(${field}, '$.${slug}')`
+      : `json_${action === 'create' ? 'insert' : 'remove'}(${field}, '$.${slug}'`;
 
-  let json = `json_${jsonAction}(${RONIN_MODEL_SYMBOLS.FIELD}${pluralType}, '$.${slug}'`;
   if (jsonValue) json += `, ${prepareStatementValue(statementParams, jsonValue)}`;
   json += ')';
 

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -454,7 +454,7 @@ test('update existing field (slug)', () => {
       params: [],
     },
     {
-      statement: `UPDATE "ronin_schema" SET "fields" = json_patch(json_extract("fields", '$.email'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_set("fields", '$.email', json_patch(json_extract("fields", '$.email'), ?1)), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -494,7 +494,7 @@ test('update existing field (name)', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "ronin_schema" SET "fields" = json_patch(json_extract("fields", '$.email'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_set("fields", '$.email', json_patch(json_extract("fields", '$.email'), ?1)), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1373,7 +1373,7 @@ test('update existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "ronin_schema" SET "presets" = json_patch(json_extract("presets", '$.company_employees'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "presets" = json_set("presets", '$.company_employees', json_patch(json_extract("presets", '$.company_employees'), ?1)), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newPresetDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -454,7 +454,7 @@ test('update existing field (slug)', () => {
       params: [],
     },
     {
-      statement: `UPDATE "ronin_schema" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_patch(json_extract("fields", '$.email'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -494,7 +494,7 @@ test('update existing field (name)', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "ronin_schema" SET "fields" = json_patch("fields", '$.email', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "fields" = json_patch(json_extract("fields", '$.email'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newFieldDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -1373,7 +1373,7 @@ test('update existing preset', () => {
 
   expect(statements).toEqual([
     {
-      statement: `UPDATE "ronin_schema" SET "presets" = json_patch("presets", '$.company_employees', ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
+      statement: `UPDATE "ronin_schema" SET "presets" = json_patch(json_extract("presets", '$.company_employees'), ?1), "ronin.updatedAt" = ?2 WHERE ("slug" = ?3) RETURNING *`,
       params: [
         JSON.stringify(newPresetDetails),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),


### PR DESCRIPTION
This ensures that changes to fields, indexes, triggers, and presets are stored correctly in the DB.