### PR TITLE
Do not require models to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ transaction.models;
 //   slug: 'account'
 //   ...
 // }]
+
+transaction.queries;
+// [{
+//   create: { model: { slug: 'account' }}
+// }, {
+//   get: { accounts: null }
+// }]
 ```
 
 #### Types

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ const { statements } = new Transaction(queries);
 // }]
 ```
 
-Additionally, following types are being exported:
+### Types
+
+In total, the following types are being exported:
 
 ```typescript
 import type {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const { statements } = new Transaction(queries);
 // }]
 ```
 
-### Types
+#### Types
 
 In total, the following types are being exported:
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ transaction.models;
 //   slug: 'account'
 //   ...
 // }]
-
-transaction.queries;
-// [{
-//   create: { model: { slug: 'account' }}
-// }, {
-//   get: { accounts: null }
-// }]
 ```
 
 #### Types

--- a/README.md
+++ b/README.md
@@ -39,24 +39,18 @@ You will just need to make sure that, once you [create a pull request](https://d
 The programmatic API of the RONIN compiler looks like this:
 
 ```typescript
-import {
-  Transaction,
+import { Transaction, type Query } from '@ronin/compiler';
 
-  type Query,
-  type Model
-} from '@ronin/compiler';
-
-const queries: Array<Query> = [{
-  get: {
-    accounts: null
+const queries: Array<Query> = [
+  {
+    create: { model: { slug: 'account' } }
+  },
+  {
+    get: { accounts: null }
   }
-}];
+];
 
-const models: Array<Model> = [{
-  slug: 'account'
-}];
-
-const { statements } = new Transaction(queries, models);
+const { statements } = new Transaction(queries);
 // [{
 //   statement: 'SELECT * FROM "accounts"',
 //   params: [],
@@ -64,12 +58,34 @@ const { statements } = new Transaction(queries, models);
 // }]
 ```
 
+Additionally, following types are being exported:
+
+```typescript
+import type {
+  Query,
+
+  Model,
+  ModelField,
+  ModelIndex,
+  ModelTrigger,
+  ModelPreset,
+
+  Statement,
+  Result
+} from '@ronin/compiler';
+```
+
 #### Options
 
 To fine-tune the behavior of the compiler, you can pass the following options:
 
 ```typescript
-new Transaction(queries, models, {
+new Transaction(queries, {
+  // A list of models that already existing inside the database.
+  models: [
+    { slug: 'account' }
+  ],
+
   // Instead of returning an array of parameters for every statement (which allows for
   // preventing SQL injections), all parameters are inlined directly into the SQL strings.
   // This option should only be used if the generated SQL will be manually verified.

--- a/README.md
+++ b/README.md
@@ -39,22 +39,29 @@ You will just need to make sure that, once you [create a pull request](https://d
 The programmatic API of the RONIN compiler looks like this:
 
 ```typescript
-import { Transaction, type Query } from '@ronin/compiler';
+import { Transaction } from '@ronin/compiler';
 
-const queries: Array<Query> = [
+const transaction = new Transaction([
   {
     create: { model: { slug: 'account' } }
   },
   {
     get: { accounts: null }
   }
-];
+]);
 
-const { statements } = new Transaction(queries);
+transaction.statements;
 // [{
 //   statement: 'SELECT * FROM "accounts"',
 //   params: [],
 //   returning: true,
+// }]
+
+transaction.models;
+// [{
+//   name: 'Account',
+//   slug: 'account'
+//   ...
 // }]
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,9 @@ export class Transaction {
 
   constructor(
     queries: Array<Query>,
-    models: Array<PublicModel>,
-    options?: Parameters<typeof compileQueries>[2],
+    options?: Parameters<typeof compileQueries>[2] & { models?: Array<PublicModel> },
   ) {
-    this.statements = compileQueries(queries, models, options);
+    this.statements = compileQueries(queries, options?.models || [], options);
   }
 
   formatOutput(results: Array<Result>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,3 +98,6 @@ export type {
 
 // Expose query types
 export type { Query, Statement } from '@/src/types/query';
+
+// Expose result types
+export type { Result } from '@/src/types/result';

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,16 @@ const compileResults = (results: Array<Result>) => {
 
 export class Transaction {
   statements: Array<Statement>;
+  models: Array<PublicModel>;
 
   constructor(
     queries: Array<Query>,
     options?: Parameters<typeof compileQueries>[2] & { models?: Array<PublicModel> },
   ) {
-    this.statements = compileQueries(queries, options?.models || [], options);
+    const models = options?.models || [];
+
+    this.statements = compileQueries(queries, models, options);
+    this.models = models;
   }
 
   formatOutput(results: Array<Result>) {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -25,7 +25,7 @@ test('get single record with non-existing field', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -56,7 +56,7 @@ test('get single record with non-existing model', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -97,7 +97,7 @@ test('get single record with empty `with` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -133,7 +133,7 @@ test('set single record with empty `to` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -166,7 +166,7 @@ test('add single record with empty `to` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -199,7 +199,7 @@ test('get single record with `before` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -232,7 +232,7 @@ test('get single record with `after` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -266,7 +266,7 @@ test('get multiple records with `before` and `after` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -299,7 +299,7 @@ test('get multiple records with empty `before` instruction', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -21,7 +21,7 @@ test('get multiple records before cursor', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -59,7 +59,7 @@ test('get multiple records before cursor ordered by string field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -97,7 +97,7 @@ test('get multiple records before cursor ordered by boolean field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -135,7 +135,7 @@ test('get multiple records before cursor ordered by number field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -173,7 +173,7 @@ test('get multiple records before cursor ordered by empty string field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -211,7 +211,7 @@ test('get multiple records before cursor ordered by empty boolean field', () => 
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -249,7 +249,7 @@ test('get multiple records before cursor ordered by empty number field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -287,7 +287,7 @@ test('get multiple records before cursor while filtering', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -318,7 +318,7 @@ test('try to paginate without providing page size', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -64,7 +64,7 @@ test('get single record for preset', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -148,7 +148,7 @@ test('get single record for preset containing field with condition', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -231,7 +231,7 @@ test('get single record for preset containing field without condition', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -291,7 +291,7 @@ test('get single record for preset on existing object instruction', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -347,7 +347,7 @@ test('get single record for preset on existing array instruction', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -386,7 +386,7 @@ test('get single record including parent record (many-to-one)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -425,7 +425,7 @@ test('get single record including child records (one-to-many, defined manually)'
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -463,7 +463,7 @@ test('get single record including child records (one-to-many, defined automatica
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -499,7 +499,7 @@ test('try get single record with non-existing preset', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -31,7 +31,7 @@ test('get single record including unrelated record without filter', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -88,7 +88,7 @@ test('get single record including unrelated record with filter', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -127,7 +127,7 @@ test('get single record including unrelated records without filter', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -184,7 +184,7 @@ test('get single record including unrelated records with filter', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -227,7 +227,7 @@ test('get single record including unrelated ordered record', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -270,7 +270,7 @@ test('get single record including unrelated ordered records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -300,7 +300,7 @@ test('get single record including ephemeral field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -342,7 +342,7 @@ test('get single record including ephemeral field containing expression', () => 
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -374,7 +374,7 @@ test('get single record including deeply nested ephemeral field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -18,7 +18,7 @@ test('get multiple records limited to amount', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -27,7 +27,7 @@ test('get multiple records ordered by field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -71,7 +71,7 @@ test('get multiple records ordered by expression', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -111,7 +111,7 @@ test('get multiple records ordered by multiple fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -18,7 +18,7 @@ test('get single record with specific field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -52,7 +52,7 @@ test('get single record with specific fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -36,7 +36,7 @@ test('set single record to new string field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -81,7 +81,7 @@ test('set single record to new string field with expression referencing fields',
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -132,7 +132,7 @@ test('set single record to new one-cardinality link field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -186,7 +186,7 @@ test('set single record to new many-cardinality link field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -254,7 +254,7 @@ test('set single record to new many-cardinality link field (add)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -318,7 +318,7 @@ test('set single record to new many-cardinality link field (remove)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -367,7 +367,7 @@ test('set single record to new json field with array', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -417,7 +417,7 @@ test('set single record to new json field with object', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -466,7 +466,7 @@ test('set single record to new grouped string field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -527,7 +527,7 @@ test('set single record to new grouped link field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -576,7 +576,7 @@ test('set single record to new grouped json field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -641,7 +641,7 @@ test('set single record to result of nested query', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -694,7 +694,7 @@ test('add multiple records with nested sub query', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -751,7 +751,7 @@ test('add multiple records with nested sub query including additional fields', (
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -803,7 +803,7 @@ test('add multiple records with nested sub query and specific fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -859,7 +859,7 @@ test('add multiple records with nested sub query and specific meta fields', () =
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -921,7 +921,7 @@ test('try to add multiple records with nested sub query including non-existent f
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -29,7 +29,7 @@ test('get single record with field being value', async () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -80,7 +80,7 @@ test('get single record with field not being value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -118,7 +118,7 @@ test('get single record with field not being empty', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -156,7 +156,7 @@ test('get single record with field starting with value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -194,7 +194,7 @@ test('get single record with field not starting with value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -232,7 +232,7 @@ test('get single record with field ending with value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -270,7 +270,7 @@ test('get single record with field not ending with value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -308,7 +308,7 @@ test('get single record with field containing value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -346,7 +346,7 @@ test('get single record with field not containing value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -384,7 +384,7 @@ test('get single record with field greater than value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -422,7 +422,7 @@ test('get single record with field greater or equal to value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -460,7 +460,7 @@ test('get single record with field less than value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -498,7 +498,7 @@ test('get single record with field less or equal to value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -543,7 +543,7 @@ test('get single record with multiple fields being value', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -591,7 +591,7 @@ test('get single record with link field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -634,7 +634,7 @@ test('get single record with link field and id', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -678,7 +678,7 @@ test('get single record with link field and id with condition', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -716,7 +716,7 @@ test('get single record with json field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -761,7 +761,7 @@ test('get single record with one of fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -804,7 +804,7 @@ test('get single record with one of field conditions', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -842,7 +842,7 @@ test('get single record with one of field values', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -884,7 +884,7 @@ test('get single record with one of field values in group', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -925,7 +925,7 @@ test('get single record with name identifier', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -966,7 +966,7 @@ test('get single record with slug identifier', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -60,7 +60,7 @@ test('create new model', () => {
 
   const models: Array<Model> = [];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -121,7 +121,7 @@ test('create new model with suitable default identifiers', () => {
 
   const models: Array<Model> = [];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements[1].params[7]).toEqual('name');
   expect(transaction.statements[1].params[8]).toEqual('handle');
@@ -147,7 +147,7 @@ test('update existing model (slug)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -192,7 +192,7 @@ test('update existing model (plural name)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -219,7 +219,7 @@ test('drop existing model', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -252,7 +252,7 @@ test('query a model that was just created', () => {
 
   const models: Array<Model> = [];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements[2]).toEqual({
     statement: 'SELECT * FROM "accounts" LIMIT 1',
@@ -284,7 +284,7 @@ test('query a model that was just updated', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements[2]).toEqual({
     statement: 'SELECT * FROM "users" LIMIT 1',
@@ -316,7 +316,7 @@ test('query a model that was just dropped', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -352,7 +352,7 @@ test('create new field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -401,7 +401,7 @@ test('create new field with options', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -446,7 +446,7 @@ test('update existing field (slug)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -490,7 +490,7 @@ test('update existing field (name)', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -523,7 +523,7 @@ test('drop existing field', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -565,7 +565,7 @@ test('create new index', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -616,7 +616,7 @@ test('create new index with filter', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -672,7 +672,7 @@ test('create new index with field expressions', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -720,7 +720,7 @@ test('create new index with ordered and collated fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -767,7 +767,7 @@ test('create new unique index', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -804,7 +804,7 @@ test('drop existing index', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -857,7 +857,7 @@ test('create new trigger for creating records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -926,7 +926,7 @@ test('create new trigger for creating records with targeted fields', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1002,7 +1002,7 @@ test('create new trigger for creating records with multiple effects', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1083,7 +1083,7 @@ test('create new per-record trigger for creating records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1159,7 +1159,7 @@ test('create new per-record trigger for removing records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1234,7 +1234,7 @@ test('create new per-record trigger with filters for creating records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1279,7 +1279,7 @@ test('drop existing trigger', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1324,7 +1324,7 @@ test('create new preset', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1369,7 +1369,7 @@ test('update existing preset', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1402,7 +1402,7 @@ test('drop existing preset', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -1430,7 +1430,7 @@ test('try to update existing model that does not exist', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }
@@ -1486,7 +1486,7 @@ test('try to create new trigger with targeted fields and wrong action', () => {
   let error: Error | undefined;
 
   try {
-    new Transaction(queries, models);
+    new Transaction(queries, { models });
   } catch (err) {
     error = err as Error;
   }

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -31,7 +31,8 @@ test('inline statement values', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models, {
+  const transaction = new Transaction(queries, {
+    models,
     inlineParams: true,
   });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -16,7 +16,7 @@ test('get single record', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -52,7 +52,7 @@ test('remove single record', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {
@@ -78,7 +78,7 @@ test('count multiple records', () => {
     },
   ];
 
-  const transaction = new Transaction(queries, models);
+  const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements).toEqual([
     {


### PR DESCRIPTION
This change simplifies the programmatic interface even further, by making models an option that does not need to be provided explicitly, since models may also be created inside the transaction itself, using a query.