### PR TITLE
Update models for subsequent queries

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -121,7 +121,7 @@ export type ModelTriggerField<T extends Array<ModelField> = Array<ModelField>> =
 
 export type ModelTrigger<T extends Array<ModelField> = Array<ModelField>> = {
   /**
-   * The identifier of the index.
+   * The identifier of the trigger.
    */
   slug?: string;
   /** The type of query for which the trigger should fire. */

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -120,6 +120,10 @@ export type ModelTriggerField<T extends Array<ModelField> = Array<ModelField>> =
 };
 
 export type ModelTrigger<T extends Array<ModelField> = Array<ModelField>> = {
+  /**
+   * The identifier of the index.
+   */
+  slug?: string;
   /** The type of query for which the trigger should fire. */
   action: 'INSERT' | 'UPDATE' | 'DELETE';
   /** When the trigger should fire in the case that a matching query is executed. */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -51,6 +51,8 @@ export const RONIN_MODEL_FIELD_REGEX = new RegExp(
 type RoninErrorCode =
   | 'MODEL_NOT_FOUND'
   | 'FIELD_NOT_FOUND'
+  | 'INDEX_NOT_FOUND'
+  | 'TRIGGER_NOT_FOUND'
   | 'PRESET_NOT_FOUND'
   | 'INVALID_WITH_VALUE'
   | 'INVALID_TO_VALUE'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -64,6 +64,13 @@ type RoninErrorCode =
   | 'MISSING_INSTRUCTION'
   | 'MISSING_FIELD';
 
+export const MODEL_ENTITY_ERROR_CODES = {
+  field: 'FIELD_NOT_FOUND',
+  index: 'INDEX_NOT_FOUND',
+  trigger: 'TRIGGER_NOT_FOUND',
+  preset: 'PRESET_NOT_FOUND',
+} as const;
+
 interface Issue {
   message: string;
   path: Array<string | number>;

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -18,6 +18,7 @@ import type {
   Statement,
 } from '@/src/types/query';
 import {
+  MODEL_ENTITY_ERROR_CODES,
   RONIN_MODEL_SYMBOLS,
   RoninError,
   convertToCamelCase,
@@ -987,14 +988,7 @@ export const transformMetaQuery = (
   ) {
     throw new RoninError({
       message: `No ${entity} with slug "${slug}" defined in model "${existingModel.name}".`,
-      code: (
-        {
-          field: 'FIELD_NOT_FOUND',
-          index: 'INDEX_NOT_FOUND',
-          trigger: 'TRIGGER_NOT_FOUND',
-          preset: 'PRESET_NOT_FOUND',
-        } as const
-      )[entity],
+      code: MODEL_ENTITY_ERROR_CODES[entity],
     });
   }
 

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,9 +1,9 @@
+import fixtureData from '@/fixtures/data.json';
 import { type Model, type Query, Transaction } from '@/src/index';
 import { Engine } from '@ronin/engine';
 import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
 import type { Row, Statement } from '@ronin/engine/types';
-import fixtureData from './data.json';
 
 const engine = new Engine({
   resolvers: [

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -53,7 +53,7 @@ const prefillDatabase = async (databaseName: string, models: Array<Model>) => {
     });
 
     await engine.queryDatabase(databaseName, [
-      modelTransaction.statements[0],
+      ...modelTransaction.statements.filter((item) => !item.returning),
       ...dataStatements,
     ]);
   }

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -179,12 +179,12 @@ test('set single record to new many-cardinality link field', () => {
   const queries: Array<Query> = [
     {
       set: {
-        post: {
+        account: {
           with: {
-            id: 'pos_zgoj3xav8tpcte1s',
+            id: 'acc_39h8fhe98hefah8',
           },
           to: {
-            comments: [{ content: 'Great post!' }],
+            followers: [{ handle: 'david' }],
           },
         },
       },
@@ -193,22 +193,17 @@ test('set single record to new many-cardinality link field', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'post',
+      slug: 'account',
       fields: [
         {
-          slug: 'comments',
-          type: 'link',
-          target: 'comment',
-          kind: 'many',
-        },
-      ],
-    },
-    {
-      slug: 'comment',
-      fields: [
-        {
-          slug: 'content',
+          slug: 'handle',
           type: 'string',
+        },
+        {
+          slug: 'followers',
+          type: 'link',
+          target: 'account',
+          kind: 'many',
         },
       ],
     },
@@ -218,15 +213,15 @@ test('set single record to new many-cardinality link field', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'DELETE FROM "ronin_link_post_comments" WHERE ("source" = ?1)',
-      params: ['pos_zgoj3xav8tpcte1s'],
+      statement: 'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1)',
+      params: ['acc_39h8fhe98hefah8'],
     },
     {
       statement:
-        'INSERT INTO "ronin_link_post_comments" ("source", "target", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "comments" WHERE ("content" = ?2) LIMIT 1), ?3, ?4, ?5)',
+        'INSERT INTO "ronin_link_account_followers" ("source", "target", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1), ?3, ?4, ?5)',
       params: [
-        'pos_zgoj3xav8tpcte1s',
-        'Great post!',
+        'acc_39h8fhe98hefah8',
+        'david',
         expect.stringMatching(RECORD_ID_REGEX),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -234,8 +229,8 @@ test('set single record to new many-cardinality link field', () => {
     },
     {
       statement:
-        'UPDATE "posts" SET "ronin.updatedAt" = ?1 WHERE ("id" = ?2) RETURNING *',
-      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'pos_zgoj3xav8tpcte1s'],
+        'UPDATE "accounts" SET "ronin.updatedAt" = ?1 WHERE ("id" = ?2) RETURNING *',
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8'],
       returning: true,
     },
   ]);

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -662,15 +662,15 @@ test('get single record with link field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
-
-  const [[targetRecord]] = await queryEphemeralDatabase(models, [
+  const [[targetRecord], ...rows] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
       params: [],
     },
+    ...transaction.statements,
   ]);
+
+  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
 
   expect(result.record?.account).toBe(targetRecord.id);
 });


### PR DESCRIPTION
This change makes it possible for subsequent queries within the same transaction to make use of changes made to model entities in previous queries:

```typescript
await batch(() => [
  alter.model('account').create.field({ slug: 'email' }),
  add.account.to({ email: 'test@site.org' })
]);
```

This was already previously possible with queries that only affected top-level attributes of models (see below), but not yet for queries that only affect nested model entities, meaning fields, indexes, triggers, or presets.

```typescript
await batch(() => [
  alter.model('account').to({ slug: 'users' }),
  add.user.to({ name: 'Test' })
]);
```