### PR TITLE
Added output tests for creating and updating records

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,12 +114,12 @@ export class Transaction {
       // Whether the query will interact with a single record, or multiple at the same time.
       const single = queryModel !== model.pluralSlug;
 
-      // The query is targeting a single record
+      // The query is targeting a single record.
       if (single) {
         return { record: this.formatRecord(model, result[0] as NativeRecord) };
       }
 
-      // The query is targeting multiple records
+      // The query is targeting multiple records.
       return {
         records: result.map((resultItem) => {
           return this.formatRecord(model, resultItem as NativeRecord);

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,12 @@ export class Transaction {
   }
 
   prepareResults(results: Array<Array<Row>>): Array<Result> {
-    return results.map((result, index): Result => {
+    // Filter out results whose statements are not expected to return any data.
+    const relevantResults = results.filter((_, index) => {
+      return this.statements[index].returning;
+    });
+
+    return relevantResults.map((result, index): Result => {
       const query = this.queries.at(-index) as Query;
       const { queryModel } = splitQuery(query);
       const model = getModelBySlug(this.models, queryModel);

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,20 @@ export class Transaction {
       const { queryModel } = splitQuery(query);
       const model = getModelBySlug(this.models, queryModel);
 
-      return { record: this.formatRecord(model, result[0] as NativeRecord) };
+      // Whether the query will interact with a single record, or multiple at the same time.
+      const single = queryModel !== model.pluralSlug;
+
+      // The query is targeting a single record
+      if (single) {
+        return { record: this.formatRecord(model, result[0] as NativeRecord) };
+      }
+
+      // The query is targeting multiple records
+      return {
+        records: result.map((resultItem) => {
+          return this.formatRecord(model, resultItem as NativeRecord);
+        }),
+      };
     });
   }
 }

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -74,6 +74,16 @@ export const handleTo = (
       splitQuery(symbol.value);
     const subQueryModel = getModelBySlug(models, subQueryModelSlug);
 
+    // If specific fields were selected by the sub query, we also need to include the
+    // ID field, since we can't generate fresh IDs for every record that is being added
+    // by the sub query, since the ID would have to be generated in JavaScript and we
+    // don't know how many records will be added by the sub query.
+    if (subQueryInstructions?.selecting) {
+      const currentFields = new Set(subQueryInstructions.selecting);
+      currentFields.add('id');
+      subQueryInstructions.selecting = Array.from(currentFields);
+    }
+
     const subQuerySelectedFields = subQueryInstructions?.selecting;
     const subQueryIncludedFields = subQueryInstructions?.including;
 
@@ -122,7 +132,20 @@ export const handleTo = (
       } as unknown as Array<string>;
     }
 
-    return compileQueryInput(symbol.value, models, statementParams).main.statement;
+    let statement = '';
+
+    if (subQuerySelectedFields) {
+      const columns = [...subQueryFields, ...defaultFieldsToAdd.map(([key]) => key)].map(
+        (field) => {
+          return getFieldFromModel(model, field, 'to').fieldSelector;
+        },
+      );
+
+      statement = `(${columns.join(', ')}) `;
+    }
+
+    statement += compileQueryInput(symbol.value, models, statementParams).main.statement;
+    return statement;
   }
 
   // Assign default field values to the provided instruction.

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -134,12 +134,17 @@ export const handleTo = (
 
     let statement = '';
 
+    // If specific fields were selected by the sub query, we need to list their respective
+    // column names in the SQL statement, so that SQLite can reliably associate the
+    // values retrieved by the sub query with the correct columns in the root query.
     if (subQuerySelectedFields) {
-      const columns = [...subQueryFields, ...defaultFieldsToAdd.map(([key]) => key)].map(
-        (field) => {
-          return getFieldFromModel(model, field, 'to').fieldSelector;
-        },
-      );
+      const selectedFields = [
+        ...subQueryFields,
+        ...defaultFieldsToAdd.map(([key]) => key),
+      ];
+      const columns = selectedFields.map((field) => {
+        return getFieldFromModel(model, field, 'to').fieldSelector;
+      });
 
       statement = `(${columns.join(', ')}) `;
     }

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -76,8 +76,9 @@ export const handleTo = (
 
     // If specific fields were selected by the sub query, we also need to include the
     // ID field, since we can't generate fresh IDs for every record that is being added
-    // by the sub query, since the ID would have to be generated in JavaScript and we
-    // don't know how many records will be added by the sub query.
+    // by the sub query, since the ID would have to be generated in JavaScript (due to
+    // the specific ID format RONIN is using) and we don't know how many records will be
+    // added by the sub query.
     if (subQueryInstructions?.selecting) {
       const currentFields = new Set(subQueryInstructions.selecting);
       currentFields.add('id');

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -136,8 +136,8 @@ export const handleTo = (
     let statement = '';
 
     // If specific fields were selected by the sub query, we need to list their respective
-    // column names in the SQL statement, so that SQLite can reliably associate the
-    // values retrieved by the sub query with the correct columns in the root query.
+    // column names in the SQL statement, so that SQLite can reliably associate the values
+    // retrieved by the sub query with the correct columns in the root query.
     if (subQuerySelectedFields) {
       const selectedFields = [
         ...subQueryFields,

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -42,14 +42,14 @@
     ],
     "team": [
       {
-        "id": "team_39h8fhe98hefah8",
+        "id": "tea_39h8fhe98hefah8",
         "locations": {
           "europe": "berlin"
         },
         "billing.currency": "EUR"
       },
       {
-        "id": "team_39h8fhe98hefah9",
+        "id": "tea_39h8fhe98hefah9",
         "locations": {
           "europe": "london"
         },

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -30,8 +30,7 @@ const prefillDatabase = async (databaseName: string, models: Array<Model>) => {
       return item.slug === model.slug;
     }) as Model;
 
-    const data = fixtureData[updatedModel.slug as keyof typeof fixtureData];
-    if (!data) throw new Error(`No fixture data found for model "${updatedModel.name}"`);
+    const data = fixtureData[updatedModel.slug as keyof typeof fixtureData] || [];
 
     const formattedData = data.map((row) => {
       const newRow: Record<string, unknown> = {};

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -799,17 +799,17 @@ test('add multiple records with nested sub query', async () => {
   );
 });
 
-test('add multiple records with nested sub query including additional fields', () => {
+test('add multiple records with nested sub query including additional fields', async () => {
   const queries: Array<Query> = [
     {
       add: {
-        newAccounts: {
+        users: {
           to: {
             [RONIN_MODEL_SYMBOLS.QUERY]: {
               get: {
-                oldAccounts: {
+                accounts: {
                   including: {
-                    firstName: 'custom-first-name',
+                    nonExistingField: 'Custom Field Value',
                   },
                 },
               },
@@ -822,7 +822,7 @@ test('add multiple records with nested sub query including additional fields', (
 
   const models: Array<Model> = [
     {
-      slug: 'oldAccount',
+      slug: 'account',
       fields: [
         {
           slug: 'handle',
@@ -831,14 +831,14 @@ test('add multiple records with nested sub query including additional fields', (
       ],
     },
     {
-      slug: 'newAccount',
+      slug: 'user',
       fields: [
         {
           slug: 'handle',
           type: 'string',
         },
         {
-          slug: 'firstName',
+          slug: 'nonExistingField',
           type: 'string',
         },
       ],
@@ -850,9 +850,21 @@ test('add multiple records with nested sub query including additional fields', (
   expect(transaction.statements).toEqual([
     {
       statement:
-        'INSERT INTO "new_accounts" SELECT *, ?1 as "firstName" FROM "old_accounts" RETURNING *',
-      params: ['custom-first-name'],
+        'INSERT INTO "users" SELECT *, ?1 as "nonExistingField" FROM "accounts" RETURNING *',
+      params: ['Custom Field Value'],
       returning: true,
+    },
+  ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toMatchObject([
+    {
+      nonExistingField: 'Custom Field Value',
+    },
+    {
+      nonExistingField: 'Custom Field Value',
     },
   ]);
 });

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -175,7 +175,7 @@ test('set single record to new one-cardinality link field', async () => {
   expect(result.record?.account).toBe(targetRecord.id);
 });
 
-test('set single record to new many-cardinality link field', () => {
+test('set single record to new many-cardinality link field', async () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -234,6 +234,11 @@ test('set single record to new many-cardinality link field', () => {
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+
+  expect(result.record?.followers).toBeUndefined();
 });
 
 test('set single record to new many-cardinality link field (add)', () => {


### PR DESCRIPTION
This change adds output transformation assertions for all tests of the `to` query instruction, which means covering the cases in which records are created or updated.