### PR TITLE
Added pagination cursors in output

### DIFF
--- a/src/instructions/before-after.ts
+++ b/src/instructions/before-after.ts
@@ -2,12 +2,8 @@ import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
 import { RoninError } from '@/src/utils/helpers';
 import { getFieldFromModel } from '@/src/utils/model';
+import { CURSOR_NULL_PLACEHOLDER, CURSOR_SEPARATOR } from '@/src/utils/pagination';
 import { prepareStatementValue } from '@/src/utils/statement';
-
-// The separator and NULL placeholder have to be somewhat unique so that they don't
-// conflict with any other row values that might be used in the cursor.
-export const CURSOR_SEPARATOR = ',';
-export const CURSOR_NULL_PLACEHOLDER = 'RONIN_NULL';
 
 /**
  * Generates SQL syntax for the `before` or `after` query instructions, which are used
@@ -17,7 +13,7 @@ export const CURSOR_NULL_PLACEHOLDER = 'RONIN_NULL';
  * `moreBefore` and `moreAfter` properties available on a list of records
  * retrieved from RONIN.
  *
- * @param model - The model being addressed in the query.
+ * @param model - The model associated with the current query.
  * @param statementParams - A collection of values that will automatically be
  * inserted into the query by SQLite.
  * @param instructions - The instructions associated with the current query.

--- a/src/instructions/ordered-by.ts
+++ b/src/instructions/ordered-by.ts
@@ -7,7 +7,7 @@ import { getSymbol, parseFieldExpression } from '@/src/utils/statement';
  * Generates the SQL syntax for the `orderedBy` query instruction, which allows for
  * ordering the list of records that are returned.
  *
- * @param model - The model being addressed in the query.
+ * @param model - The model associated with the current query.
  * @param instruction - The `orderedBy` instruction provided in the current query.
  *
  * @returns The SQL syntax for the provided `orderedBy` instruction.

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -20,7 +20,7 @@ import { composeConditions, getSymbol } from '@/src/utils/statement';
  * values that should be stored in the records that are being addressed.
  *
  * @param models - A list of models.
- * @param model - The model being addressed in the query.
+ * @param model - The model associated with the current query.
  * @param statementParams - A collection of values that will automatically be
  * inserted into the query by SQLite.
  * @param queryType - The type of query that is being executed.

--- a/src/instructions/with.ts
+++ b/src/instructions/with.ts
@@ -54,7 +54,7 @@ export type { WithValue, WithValueOptions, WithFilters, WithCondition };
  * the records that should be addressed.
  *
  * @param models - A list of models.
- * @param model - The model being addressed in the query.
+ * @param model - The model associated with the current query.
  * @param statementParams - A collection of values that will automatically be
  * inserted into the query by SQLite.
  * @param instruction - The `with` instruction included in a query.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -9,6 +9,9 @@ export const RECORD_ID_REGEX = /[a-z]{3}_[a-z0-9]{16}/;
 /** A regex for asserting RONIN record timestamps. */
 export const RECORD_TIMESTAMP_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
 
+/** A regex for asserting RONIN pagination cursors. */
+export const PAGINATION_CURSOR_REGEX = /^\d{13}$/;
+
 /**
  * A list of placeholders that can be located inside queries after those queries were
  * serialized into JSON objects.
@@ -290,6 +293,17 @@ export const expand = (obj: NestedObject) => {
       }, res);
     return res;
   }, {});
+};
+
+/**
+ * Picks a property from an object and returns the value of the property.
+ *
+ * @param obj - The object from which the property should be read.
+ *
+ * @returns The value of the property.
+ */
+export const getProperty = (obj: NestedObject, path: string) => {
+  return path.split('.').reduce((acc, key) => acc?.[key] as NestedObject, obj);
 };
 
 /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,15 +3,6 @@ import type { Query, QuerySchemaType, QueryType } from '@/src/types/query';
 
 import { init as cuid } from '@paralleldrive/cuid2';
 
-/** A regex for asserting RONIN record IDs. */
-export const RECORD_ID_REGEX = /[a-z]{3}_[a-z0-9]{16}/;
-
-/** A regex for asserting RONIN record timestamps. */
-export const RECORD_TIMESTAMP_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
-
-/** A regex for asserting RONIN pagination cursors. */
-export const PAGINATION_CURSOR_REGEX = /^\d{13}$/;
-
 /**
  * A list of placeholders that can be located inside queries after those queries were
  * serialized into JSON objects.

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,50 @@
+import type { Model } from '@/src/types/model';
+import type { GetInstructions } from '@/src/types/query';
+import type { NativeRecord } from '@/src/types/result';
+import { getProperty } from '@/src/utils/helpers';
+import { getFieldFromModel } from '@/src/utils/model';
+
+// The separator and NULL placeholder have to be somewhat unique so that they don't
+// conflict with any other row values that might be used in the cursor.
+export const CURSOR_SEPARATOR = ',';
+export const CURSOR_NULL_PLACEHOLDER = 'RONIN_NULL';
+
+/**
+ * Generates a pagination cursor for the provided record.
+ *
+ * @param model - The schema that defined the structure of the record.
+ * @param orderedBy - An object specifying the sorting order for the record fields.
+ * @param record - The record for which the pagination cursor should be generated.
+ *
+ * @returns The generated pagination cursor.
+ */
+export const generatePaginationCursor = (
+  model: Model,
+  orderedBy: GetInstructions['orderedBy'],
+  record: NativeRecord,
+): string => {
+  const { ascending = [], descending = [] } = orderedBy || {};
+  const keys = [...ascending, ...descending];
+
+  // If no fields are specified, we default to sorting by the `createdAt` field.
+  if (keys.length === 0) keys.push('ronin.createdAt');
+
+  const cursors = keys.map((fieldSlug) => {
+    const property = getProperty(record, fieldSlug as string) as unknown;
+    if (property === null || property === undefined) return CURSOR_NULL_PLACEHOLDER;
+
+    const { field } = getFieldFromModel(model, fieldSlug as string, 'orderedBy');
+
+    // If the field is of type "date", we convert its value to a timestamp.
+    if (field.type === 'date') return new Date(property as string).getTime();
+
+    // If the field is of type "link", we use the `id` property as the cursor.
+    if (field.type === 'link') return (property as { id: string }).id;
+
+    return property;
+  });
+
+  return cursors
+    .map((cursor) => encodeURIComponent(String(cursor)))
+    .join(CURSOR_SEPARATOR);
+};

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -38,10 +38,6 @@ export const generatePaginationCursor = (
     // If the field is of type "date", we convert its value to a timestamp.
     if (field.type === 'date') return new Date(property as string).getTime();
 
-    // If the field is of type "link", we use the `id` field as the cursor if the field
-    // is expanded, meaning if it contains the full resolved record.
-    if (field.type === 'link') return (property as { id?: string }).id || property;
-
     return property;
   });
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -38,8 +38,9 @@ export const generatePaginationCursor = (
     // If the field is of type "date", we convert its value to a timestamp.
     if (field.type === 'date') return new Date(property as string).getTime();
 
-    // If the field is of type "link", we use the `id` property as the cursor.
-    if (field.type === 'link') return (property as { id: string }).id;
+    // If the field is of type "link", we use the `id` field as the cursor if the field
+    // is expanded, meaning if it contains the full resolved record.
+    if (field.type === 'link') return (property as { id?: string }).id || property;
 
     return property;
   });

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -38,6 +38,10 @@
       {
         "id": "mem_39h8fhe98hefah9j",
         "account": "acc_39h8fhe98hefah9j"
+      },
+      {
+        "id": "mem_39h8fhe98hefah0j",
+        "account": "acc_39h8fhe98hefah8j"
       }
     ],
     "team": [

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -56,6 +56,20 @@
         "billing.currency": "GBP"
       }
     ],
+    "beach": [
+      {
+        "id": "bea_39h8fhe98hefah8j",
+        "name": "Bondi"
+      },
+      {
+        "id": "bea_39h8fhe98hefah9j",
+        "name": "Manly"
+      },
+      {
+        "id": "bea_39h8fhe98hefah0j",
+        "name": "Coogee"
+      }
+    ],
     "category": [
       {
         "id": "cat_39h8fhe98hefah8j",

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -1,13 +1,13 @@
 {
     "account": [
       {
-        "id": "acc_39h8fhe98hefah8",
+        "id": "acc_39h8fhe98hefah8j",
         "handle": "elaine",
         "firstName": "Elaine",
         "lastName": "Jones"
       },
       {
-        "id": "acc_39h8fhe98hefah9",
+        "id": "acc_39h8fhe98hefah9j",
         "handle": "david",
         "firstName": "David",
         "lastName": "Brown"
@@ -15,41 +15,41 @@
     ],
     "product": [
       {
-        "id": "pro_39h8fhe98hefah8",
+        "id": "pro_39h8fhe98hefah8j",
         "name": "Apple",
         "position": 1
       },
       {
-        "id": "pro_39h8fhe98hefah9",
+        "id": "pro_39h8fhe98hefah9j",
         "name": "Banana",
         "position": 2
       },
       {
-        "id": "pro_39h8fhe98hefah0",
+        "id": "pro_39h8fhe98hefah0j",
         "name": "Cherry",
         "position": 3
       }
     ],
     "member": [
       {
-        "id": "mem_39h8fhe98hefah8",
-        "account": "acc_39h8fhe98hefah8"
+        "id": "mem_39h8fhe98hefah8j",
+        "account": "acc_39h8fhe98hefah8j"
       },
       {
-        "id": "mem_39h8fhe98hefah9",
-        "account": "acc_39h8fhe98hefah9"
+        "id": "mem_39h8fhe98hefah9j",
+        "account": "acc_39h8fhe98hefah9j"
       }
     ],
     "team": [
       {
-        "id": "tea_39h8fhe98hefah8",
+        "id": "tea_39h8fhe98hefah8j",
         "locations": {
           "europe": "berlin"
         },
         "billing.currency": "EUR"
       },
       {
-        "id": "tea_39h8fhe98hefah9",
+        "id": "tea_39h8fhe98hefah9j",
         "locations": {
           "europe": "london"
         },

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -55,5 +55,15 @@
         },
         "billing.currency": "GBP"
       }
+    ],
+    "category": [
+      {
+        "id": "cat_39h8fhe98hefah8j",
+        "name": "Fruit"
+      },
+      {
+        "id": "cat_39h8fhe98hefah9j",
+        "name": "Vegetable"
+      }
     ]
   }

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -5,6 +5,15 @@ import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
 import type { Row, Statement } from '@ronin/engine/types';
 
+/** A regex for asserting RONIN record IDs. */
+export const RECORD_ID_REGEX = /[a-z]{3}_[a-z0-9]{16}/;
+
+/** A regex for asserting RONIN record timestamps. */
+export const RECORD_TIMESTAMP_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
+
+/** A regex for asserting RONIN pagination cursors. */
+export const PAGINATION_CURSOR_REGEX = /^\d{13}$/;
+
 const engine = new Engine({
   resolvers: [
     new MemoryResolver({

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -12,7 +12,7 @@ export const RECORD_ID_REGEX = /[a-z]{3}_[a-z0-9]{16}/;
 export const RECORD_TIMESTAMP_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
 
 /** A regex for asserting RONIN pagination cursors. */
-export const PAGINATION_CURSOR_REGEX = /^\d{13}$/;
+export const PAGINATION_CURSOR_REGEX = /^(?:[a-zA-Z0-9_]+,)*[a-zA-Z0-9_]*\d{13}$/;
 
 const engine = new Engine({
   resolvers: [

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { type Model, type Query, Transaction } from '@/src/index';
-import { CURSOR_NULL_PLACEHOLDER } from '@/src/instructions/before-after';
 import { RoninError } from '@/src/utils/helpers';
+import { CURSOR_NULL_PLACEHOLDER } from '@/src/utils/pagination';
 
 test('get multiple records before cursor', () => {
   const queries: Array<Query> = [

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -81,7 +81,7 @@ test('get single record for preset containing field with condition', () => {
       get: {
         view: {
           for: {
-            activeMember: 'acc_39h8fhe98hefah8',
+            activeMember: 'acc_39h8fhe98hefah8j',
           },
         },
       },
@@ -154,7 +154,7 @@ test('get single record for preset containing field with condition', () => {
     {
       statement:
         'SELECT * FROM "views" WHERE ("space" != (SELECT "space" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
-      params: ['acc_39h8fhe98hefah8'],
+      params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -166,7 +166,7 @@ test('get single record for preset containing field without condition', () => {
       get: {
         view: {
           for: {
-            activeMember: 'acc_39h8fhe98hefah8',
+            activeMember: 'acc_39h8fhe98hefah8j',
           },
         },
       },
@@ -237,7 +237,7 @@ test('get single record for preset containing field without condition', () => {
     {
       statement:
         'SELECT * FROM "views" WHERE ("space" = (SELECT "space" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
-      params: ['acc_39h8fhe98hefah8'],
+      params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -249,7 +249,7 @@ test('get single record for preset on existing object instruction', () => {
       get: {
         member: {
           with: {
-            account: 'acc_39h8fhe98hefah8',
+            account: 'acc_39h8fhe98hefah8j',
           },
           for: ['specificSpace'],
         },
@@ -297,7 +297,7 @@ test('get single record for preset on existing object instruction', () => {
     {
       statement:
         'SELECT * FROM "members" WHERE ("space" = ?1 AND "account" = ?2) LIMIT 1',
-      params: ['spa_m9h8oha94helaji', 'acc_39h8fhe98hefah8'],
+      params: ['spa_m9h8oha94helaji', 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -480,7 +480,7 @@ test('try get single record with non-existing preset', () => {
       get: {
         account: {
           for: {
-            activeMember: 'acc_39h8fhe98hefah8',
+            activeMember: 'acc_39h8fhe98hefah8j',
           },
         },
       },

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -37,3 +37,52 @@ test('get multiple records limited to amount', async () => {
   expect(result.moreBefore).toBeUndefined();
   expect(result.moreAfter).toMatch(PAGINATION_CURSOR_REGEX);
 });
+
+test('get multiple records limited to amount ordered by link field', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        members: {
+          limitedTo: 2,
+          orderedBy: {
+            descending: ['account'],
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'member',
+      fields: [
+        {
+          slug: 'account',
+          type: 'link',
+          target: 'account',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement:
+        'SELECT * FROM "members" ORDER BY "account" DESC, "ronin.createdAt" DESC LIMIT 3',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toHaveLength(2);
+  expect(result.moreBefore).toBeUndefined();
+  expect(result.moreAfter).toStartWith('acc_39h8fhe98hefah8j');
+});

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -1,12 +1,15 @@
 import { expect, test } from 'bun:test';
+import { queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
+import type { MultipleRecordResult } from '@/src/types/result';
+import { PAGINATION_CURSOR_REGEX } from '@/src/utils/helpers';
 
-test('get multiple records limited to amount', () => {
+test('get multiple records limited to amount', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        accounts: {
-          limitedTo: 20,
+        beaches: {
+          limitedTo: 2,
         },
       },
     },
@@ -14,7 +17,7 @@ test('get multiple records limited to amount', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'account',
+      slug: 'beach',
     },
   ];
 
@@ -22,9 +25,16 @@ test('get multiple records limited to amount', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY "ronin.createdAt" DESC LIMIT 21`,
+      statement: 'SELECT * FROM "beaches" ORDER BY "ronin.createdAt" DESC LIMIT 3',
       params: [],
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toHaveLength(2);
+  expect(result.moreBefore).toBeUndefined();
+  expect(result.moreAfter).toMatch(PAGINATION_CURSOR_REGEX);
 });

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'bun:test';
-import { queryEphemeralDatabase } from '@/fixtures/utils';
+import { PAGINATION_CURSOR_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
 import type { MultipleRecordResult } from '@/src/types/result';
-import { PAGINATION_CURSOR_REGEX } from '@/src/utils/helpers';
 
 test('get multiple records limited to amount', async () => {
   const queries: Array<Query> = [

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'bun:test';
+import { queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
+import type { MultipleRecordResult } from '@/src/types/result';
 import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 
-test('get multiple records ordered by field', () => {
+test('get multiple records ordered by field', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -36,9 +38,21 @@ test('get multiple records ordered by field', () => {
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toMatchObject([
+    {
+      handle: 'david',
+    },
+    {
+      handle: 'elaine',
+    },
+  ]);
 });
 
-test('get multiple records ordered by expression', () => {
+test('get multiple records ordered by expression', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -80,15 +94,29 @@ test('get multiple records ordered by expression', () => {
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toMatchObject([
+    {
+      firstName: 'David',
+      lastName: 'Brown',
+    },
+    {
+      firstName: 'Elaine',
+      lastName: 'Jones',
+    },
+  ]);
 });
 
-test('get multiple records ordered by multiple fields', () => {
+test('get multiple records ordered by multiple fields', async () => {
   const queries: Array<Query> = [
     {
       get: {
         accounts: {
           orderedBy: {
-            ascending: ['handle', 'name'],
+            ascending: ['handle', 'lastName'],
           },
         },
       },
@@ -104,7 +132,7 @@ test('get multiple records ordered by multiple fields', () => {
           type: 'string',
         },
         {
-          slug: 'name',
+          slug: 'lastName',
           type: 'string',
         },
       ],
@@ -115,9 +143,23 @@ test('get multiple records ordered by multiple fields', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC, "name" COLLATE NOCASE ASC`,
+      statement: `SELECT * FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC, "lastName" COLLATE NOCASE ASC`,
       params: [],
       returning: true,
+    },
+  ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  expect(result.records).toMatchObject([
+    {
+      handle: 'david',
+      lastName: 'Brown',
+    },
+    {
+      handle: 'elaine',
+      lastName: 'Jones',
     },
   ]);
 });

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -39,11 +39,11 @@ test('get single record with specific field', async () => {
   });
 });
 
-test('get single record with specific fields', () => {
+test('get single record with specific fields', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        beach: {
+        product: {
           selecting: ['id', 'name'],
         },
       },
@@ -52,7 +52,7 @@ test('get single record with specific fields', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'beach',
+      slug: 'product',
       fields: [
         {
           slug: 'name',
@@ -66,9 +66,17 @@ test('get single record with specific fields', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id", "name" FROM "beaches" LIMIT 1',
+      statement: 'SELECT "id", "name" FROM "products" LIMIT 1',
       params: [],
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    name: expect.any(String),
+  });
 });

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from 'bun:test';
+import { queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
+import type { SingleRecordResult } from '@/src/types/result';
+import { RECORD_ID_REGEX } from '@/src/utils/helpers';
 
-test('get single record with specific field', () => {
+test('get single record with specific field', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        category: {
+        product: {
           selecting: ['id'],
         },
       },
@@ -14,7 +17,7 @@ test('get single record with specific field', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'category',
+      slug: 'product',
     },
   ];
 
@@ -22,11 +25,18 @@ test('get single record with specific field', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id" FROM "categories" LIMIT 1',
+      statement: 'SELECT "id" FROM "products" LIMIT 1',
       params: [],
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+  });
 });
 
 test('get single record with specific fields', () => {

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -8,7 +8,7 @@ test('get single record with specific field', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        product: {
+        category: {
           selecting: ['id'],
         },
       },
@@ -17,7 +17,7 @@ test('get single record with specific field', async () => {
 
   const models: Array<Model> = [
     {
-      slug: 'product',
+      slug: 'category',
     },
   ];
 
@@ -25,7 +25,7 @@ test('get single record with specific field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id" FROM "products" LIMIT 1',
+      statement: 'SELECT "id" FROM "categories" LIMIT 1',
       params: [],
       returning: true,
     },
@@ -43,7 +43,7 @@ test('get single record with specific fields', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        product: {
+        category: {
           selecting: ['id', 'name'],
         },
       },
@@ -52,7 +52,7 @@ test('get single record with specific fields', async () => {
 
   const models: Array<Model> = [
     {
-      slug: 'product',
+      slug: 'category',
       fields: [
         {
           slug: 'name',
@@ -66,7 +66,7 @@ test('get single record with specific fields', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id", "name" FROM "products" LIMIT 1',
+      statement: 'SELECT "id", "name" FROM "categories" LIMIT 1',
       params: [],
       returning: true,
     },

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -43,7 +43,7 @@ test('get single record with specific fields', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        category: {
+        beach: {
           selecting: ['id', 'name'],
         },
       },
@@ -52,7 +52,7 @@ test('get single record with specific fields', async () => {
 
   const models: Array<Model> = [
     {
-      slug: 'category',
+      slug: 'beach',
       fields: [
         {
           slug: 'name',
@@ -66,7 +66,7 @@ test('get single record with specific fields', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id", "name" FROM "categories" LIMIT 1',
+      statement: 'SELECT "id", "name" FROM "beaches" LIMIT 1',
       params: [],
       returning: true,
     },

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'bun:test';
-import { queryEphemeralDatabase } from '@/fixtures/utils';
+import { RECORD_ID_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
 import type { SingleRecordResult } from '@/src/types/result';
-import { RECORD_ID_REGEX } from '@/src/utils/helpers';
 
 test('get single record with specific field', async () => {
   const queries: Array<Query> = [

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -114,7 +114,7 @@ test('set single record to new one-cardinality link field', async () => {
       set: {
         member: {
           with: {
-            id: 'mem_39h8fhe98hefah9',
+            id: 'mem_39h8fhe98hefah9j',
           },
           to: {
             account: {
@@ -156,7 +156,7 @@ test('set single record to new one-cardinality link field', async () => {
       params: [
         'elaine',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        'mem_39h8fhe98hefah9',
+        'mem_39h8fhe98hefah9j',
       ],
       returning: true,
     },
@@ -181,7 +181,7 @@ test('set single record to new many-cardinality link field', async () => {
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8',
+            id: 'acc_39h8fhe98hefah8j',
           },
           to: {
             followers: [{ handle: 'david' }],
@@ -214,13 +214,13 @@ test('set single record to new many-cardinality link field', async () => {
   expect(transaction.statements).toEqual([
     {
       statement: 'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1)',
-      params: ['acc_39h8fhe98hefah8'],
+      params: ['acc_39h8fhe98hefah8j'],
     },
     {
       statement:
         'INSERT INTO "ronin_link_account_followers" ("source", "target", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1), ?3, ?4, ?5)',
       params: [
-        'acc_39h8fhe98hefah8',
+        'acc_39h8fhe98hefah8j',
         'david',
         expect.stringMatching(RECORD_ID_REGEX),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -230,7 +230,7 @@ test('set single record to new many-cardinality link field', async () => {
     {
       statement:
         'UPDATE "accounts" SET "ronin.updatedAt" = ?1 WHERE ("id" = ?2) RETURNING *',
-      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8'],
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -248,7 +248,7 @@ test('set single record to new many-cardinality link field (add)', async () => {
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8',
+            id: 'acc_39h8fhe98hefah8j',
           },
           to: {
             followers: {
@@ -285,7 +285,7 @@ test('set single record to new many-cardinality link field (add)', async () => {
       statement:
         'INSERT INTO "ronin_link_account_followers" ("source", "target", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1), ?3, ?4, ?5)',
       params: [
-        'acc_39h8fhe98hefah8',
+        'acc_39h8fhe98hefah8j',
         'david',
         expect.stringMatching(RECORD_ID_REGEX),
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -295,7 +295,7 @@ test('set single record to new many-cardinality link field (add)', async () => {
     {
       statement:
         'UPDATE "accounts" SET "ronin.updatedAt" = ?1 WHERE ("id" = ?2) RETURNING *',
-      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8'],
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -313,7 +313,7 @@ test('set single record to new many-cardinality link field (remove)', async () =
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8',
+            id: 'acc_39h8fhe98hefah8j',
           },
           to: {
             followers: {
@@ -349,12 +349,12 @@ test('set single record to new many-cardinality link field (remove)', async () =
     {
       statement:
         'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1 AND "target" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['acc_39h8fhe98hefah8', 'david'],
+      params: ['acc_39h8fhe98hefah8j', 'david'],
     },
     {
       statement:
         'UPDATE "accounts" SET "ronin.updatedAt" = ?1 WHERE ("id" = ?2) RETURNING *',
-      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8'],
+      params: [expect.stringMatching(RECORD_TIMESTAMP_REGEX), 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
@@ -482,7 +482,7 @@ test('set single record to new grouped string field', async () => {
       set: {
         team: {
           with: {
-            id: 'tea_39h8fhe98hefah8',
+            id: 'tea_39h8fhe98hefah8j',
           },
           to: {
             billing: {
@@ -518,7 +518,7 @@ test('set single record to new grouped string field', async () => {
       params: [
         'USD',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        'tea_39h8fhe98hefah8',
+        'tea_39h8fhe98hefah8j',
       ],
       returning: true,
     },
@@ -536,7 +536,7 @@ test('set single record to new grouped link field', async () => {
       set: {
         team: {
           with: {
-            id: 'tea_39h8fhe98hefah8',
+            id: 'tea_39h8fhe98hefah8j',
           },
           to: {
             billing: {
@@ -584,7 +584,7 @@ test('set single record to new grouped link field', async () => {
       params: [
         'elaine',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        'tea_39h8fhe98hefah8',
+        'tea_39h8fhe98hefah8j',
       ],
       returning: true,
     },
@@ -609,7 +609,7 @@ test('set single record to new grouped json field', async () => {
       set: {
         team: {
           with: {
-            id: 'tea_39h8fhe98hefah9',
+            id: 'tea_39h8fhe98hefah9j',
           },
           to: {
             billing: {
@@ -645,7 +645,7 @@ test('set single record to new grouped json field', async () => {
       params: [
         '["receipts@test.co"]',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        'tea_39h8fhe98hefah9',
+        'tea_39h8fhe98hefah9j',
       ],
       returning: true,
     },
@@ -665,7 +665,7 @@ test('set single record to result of nested query', async () => {
       set: {
         team: {
           with: {
-            id: 'tea_39h8fhe98hefah9',
+            id: 'tea_39h8fhe98hefah9j',
           },
           to: {
             name: {
@@ -717,7 +717,7 @@ test('set single record to result of nested query', async () => {
       params: [
         'david',
         expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        'tea_39h8fhe98hefah9',
+        'tea_39h8fhe98hefah9j',
       ],
       returning: true,
     },

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -1,14 +1,13 @@
 import { expect, test } from 'bun:test';
 import { type Model, type Query, Transaction } from '@/src/index';
 
-import { queryEphemeralDatabase } from '@/fixtures/utils';
-import type { MultipleRecordResult, SingleRecordResult } from '@/src/types/result';
 import {
   RECORD_ID_REGEX,
   RECORD_TIMESTAMP_REGEX,
-  RONIN_MODEL_SYMBOLS,
-  RoninError,
-} from '@/src/utils/helpers';
+  queryEphemeralDatabase,
+} from '@/fixtures/utils';
+import type { MultipleRecordResult, SingleRecordResult } from '@/src/types/result';
+import { RONIN_MODEL_SYMBOLS, RoninError } from '@/src/utils/helpers';
 
 test('set single record to new string field', async () => {
   const queries: Array<Query> = [

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -682,7 +682,7 @@ test('get single record with link field and id', async () => {
         member: {
           with: {
             account: {
-              id: 'acc_39h8fhe98hefah9',
+              id: 'acc_39h8fhe98hefah9j',
             },
           },
         },
@@ -711,7 +711,7 @@ test('get single record with link field and id', async () => {
   expect(transaction.statements).toEqual([
     {
       statement: 'SELECT * FROM "members" WHERE ("account" = ?1) LIMIT 1',
-      params: ['acc_39h8fhe98hefah9'],
+      params: ['acc_39h8fhe98hefah9j'],
       returning: true,
     },
   ]);
@@ -719,7 +719,7 @@ test('get single record with link field and id', async () => {
   const rows = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
 
-  expect(result.record?.account).toBe('acc_39h8fhe98hefah9');
+  expect(result.record?.account).toBe('acc_39h8fhe98hefah9j');
 });
 
 test('get single record with link field and id with condition', async () => {
@@ -730,7 +730,7 @@ test('get single record with link field and id with condition', async () => {
           with: {
             account: {
               id: {
-                being: 'acc_39h8fhe98hefah9',
+                being: 'acc_39h8fhe98hefah9j',
               },
             },
           },
@@ -760,7 +760,7 @@ test('get single record with link field and id with condition', async () => {
   expect(transaction.statements).toEqual([
     {
       statement: 'SELECT * FROM "members" WHERE ("account" = ?1) LIMIT 1',
-      params: ['acc_39h8fhe98hefah9'],
+      params: ['acc_39h8fhe98hefah9j'],
       returning: true,
     },
   ]);
@@ -768,7 +768,7 @@ test('get single record with link field and id with condition', async () => {
   const rows = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
 
-  expect(result.record?.account).toBe('acc_39h8fhe98hefah9');
+  expect(result.record?.account).toBe('acc_39h8fhe98hefah9j');
 });
 
 test('get single record with json field', async () => {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -9,12 +9,8 @@ import {
   Transaction,
 } from '@/src/index';
 
-import {
-  RECORD_TIMESTAMP_REGEX,
-  RONIN_MODEL_SYMBOLS,
-  RoninError,
-} from '@/src/utils/helpers';
-import { RECORD_ID_REGEX } from '@/src/utils/helpers';
+import { RECORD_ID_REGEX, RECORD_TIMESTAMP_REGEX } from '@/fixtures/utils';
+import { RONIN_MODEL_SYMBOLS, RoninError } from '@/src/utils/helpers';
 import { SYSTEM_FIELDS } from '@/src/utils/model';
 
 test('create new model', () => {


### PR DESCRIPTION
This change brings back automatic pagination cursors for the output transformation, in cases in which the amount of records is limited using the `limitedTo` instruction, meaning cases in which pagination is activated explicitly.