### PR TITLE
Ensure option types are publicly available

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ new Transaction(queries, {
   // names themselves are aliased.
   //
   // This ensures the cleanest possible SQL statements in conjunction with the default
-  // behavior of SQLite (and all other SQL databases), where the result of a statement is
-  // a list (array) of values, which are inherently not prone to conflicts.
+  // behavior of SQL databases, where the result of a statement is a list (array) of
+  // values, which are inherently not prone to conflicts.
   //
   // If the driver being used instead returns an object for every row, the driver must
   // ensure the uniqueness of every key in that object, which means prefixing duplicated
   // column names with the name of the respective table, if multiple tables are joined.
+  //
   // Drivers that return objects for rows offer this behavior as an option that is
   // usually called "expand columns". If the driver being used does not offer such an
   // option, you can instead activate the option in the compiler, which results in longer

--- a/README.md
+++ b/README.md
@@ -103,7 +103,24 @@ new Transaction(queries, {
   // Instead of returning an array of parameters for every statement (which allows for
   // preventing SQL injections), all parameters are inlined directly into the SQL strings.
   // This option should only be used if the generated SQL will be manually verified.
-  inlineParams: true
+  inlineParams: true,
+
+  // By default, in the generated SQL statements, the compiler does not alias columns if
+  // multiple different tables with the same column names are being joined. Only the table
+  // names themselves are aliased.
+  //
+  // This ensures the cleanest possible SQL statements in conjunction with the default
+  // behavior of SQLite (and all other SQL databases), where the result of a statement is
+  // a list (array) of values, which are inherently not prone to conflicts.
+  //
+  // If the driver being used instead returns an object for every row, the driver must
+  // ensure the uniqueness of every key in that object, which means prefixing duplicated
+  // column names with the name of the respective table, if multiple tables are joined.
+  // Drivers that return objects for rows offer this behavior as an option that is
+  // usually called "expand columns". If the driver being used does not offer such an
+  // option, you can instead activate the option in the compiler, which results in longer
+  // SQL statements because any duplicated column name is aliased.
+  expandColumns: true
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export class Transaction {
     models: Array<PublicModel>,
     options?: {
       inlineParams?: boolean;
+      expandColumns?: boolean;
     },
   ): Array<Statement> => {
     const modelList = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,16 +13,25 @@ import {
 } from '@/src/utils/model';
 import { generatePaginationCursor } from '@/src/utils/pagination';
 
+interface TransactionOptions {
+  /** A list of models that already exist in the database. */
+  models?: Array<PublicModel>;
+  /**
+   * Place statement parameters directly inside the statement strings instead of
+   * separating them out into a dedicated `params` array.
+   */
+  inlineParams?: boolean;
+  /** Alias column names that are duplicated when joining multiple tables. */
+  expandColumns?: boolean;
+}
+
 export class Transaction {
   statements: Array<Statement>;
   models: Array<PrivateModel> = [];
 
   private queries: Array<Query>;
 
-  constructor(
-    queries: Array<Query>,
-    options?: Parameters<typeof this.compileQueries>[2] & { models?: Array<PublicModel> },
-  ) {
+  constructor(queries: Array<Query>, options?: TransactionOptions) {
     const models = options?.models || [];
 
     this.statements = this.compileQueries(queries, models, options);
@@ -41,10 +50,7 @@ export class Transaction {
   private compileQueries = (
     queries: Array<Query>,
     models: Array<PublicModel>,
-    options?: {
-      inlineParams?: boolean;
-      expandColumns?: boolean;
-    },
+    options?: Omit<TransactionOptions, 'models'>,
   ): Array<Statement> => {
     const modelList = [
       ROOT_MODEL,


### PR DESCRIPTION
At the moment, as mentioned on Slack by @colodenn, the type of a `Transaction` is incomplete, because our build tool removes the types of internal methods, which that type relies on.

By splitting out the configuration type into a dedicated interface, we are preventing the build tool from stripping it.