### PR TITLE
Added `expandColumns` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ class Transaction {
         query,
         modelListWithPresets,
         options?.inlineParams ? null : [],
+        { expandColumns: options?.expandColumns },
       );
 
       // Every query can only produce one main statement (which can return output), but

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,3 +195,6 @@ const CLEAN_ROOT_MODEL = omit(ROOT_MODEL, ['system']) as PublicModel;
 
 // Expose the main `Transaction` entrypoint and the root model
 export { Transaction, CLEAN_ROOT_MODEL as ROOT_MODEL };
+
+// Expose model symbols
+export { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,3 @@ const CLEAN_ROOT_MODEL = omit(ROOT_MODEL, ['system']) as PublicModel;
 
 // Expose the main `Transaction` entrypoint and the root model
 export { Transaction, CLEAN_ROOT_MODEL as ROOT_MODEL };
-
-// Expose model symbols
-export { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -1,10 +1,10 @@
 import type { WithFilters } from '@/src/instructions/with';
 import type { Model } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
-import { splitQuery } from '@/src/utils/helpers';
+import { getSymbol, splitQuery } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
 import { getModelBySlug } from '@/src/utils/model';
-import { composeConditions, getSymbol } from '@/src/utils/statement';
+import { composeConditions } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `including` query instruction, which allows for

--- a/src/instructions/ordered-by.ts
+++ b/src/instructions/ordered-by.ts
@@ -1,7 +1,8 @@
 import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
+import { getSymbol } from '@/src/utils/helpers';
 import { getFieldFromModel } from '@/src/utils/model';
-import { getSymbol, parseFieldExpression } from '@/src/utils/statement';
+import { parseFieldExpression } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `orderedBy` query instruction, which allows for

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -57,6 +57,9 @@ export const handleSelecting = (
         if (symbol?.type === 'query') {
           isJoining = true;
 
+          // If the column names should be expanded, that means we need to alias all
+          // columns of the joined table if those column names are duplicated in the
+          // current table.
           if (!options?.expandColumns) return null;
 
           const { queryModel: queryModelSlug } = splitQuery(symbol.value);
@@ -96,12 +99,12 @@ export const handleSelecting = (
           const symbol = getSymbol(value);
 
           if (symbol?.type === 'expression') {
-            value = parseFieldExpression(model, 'including', symbol.value);
+            value = `(${parseFieldExpression(model, 'including', symbol.value)})`;
+          } else {
+            value = prepareStatementValue(statementParams, value);
           }
 
-          if (typeof value === 'string' && value.startsWith('"'))
-            return `(${value}) as "${key}"`;
-          return `${prepareStatementValue(statementParams, value)} as "${key}"`;
+          return `${value} as "${key}"`;
         })
         .join(', ');
     }

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -4,6 +4,7 @@ import {
   expand,
   flatten,
   generateRecordId,
+  getSymbol,
   isObject,
   splitQuery,
 } from '@/src/utils/helpers';
@@ -13,7 +14,7 @@ import {
   getFieldFromModel,
   getModelBySlug,
 } from '@/src/utils/model';
-import { composeConditions, getSymbol } from '@/src/utils/statement';
+import { composeConditions } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `to` query instruction, which allows for providing

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -200,6 +200,49 @@ export const isObject = (value: unknown): boolean =>
   value != null && typeof value === 'object' && Array.isArray(value) === false;
 
 /**
+ * Checks if the provided value contains a RONIN model symbol (a represenation of a
+ * particular entity inside a query, such as an expression or a sub query) and returns
+ * its type and value.
+ *
+ * @param value - The value that should be checked.
+ *
+ * @returns The type and value of the symbol, if the provided value contains one.
+ */
+export const getSymbol = (
+  value: unknown,
+):
+  | {
+      type: 'query';
+      value: Query;
+    }
+  | {
+      type: 'expression';
+      value: string;
+    }
+  | null => {
+  if (!isObject(value)) return null;
+  const objectValue = value as
+    | Record<typeof RONIN_MODEL_SYMBOLS.QUERY, Query>
+    | Record<typeof RONIN_MODEL_SYMBOLS.EXPRESSION, string>;
+
+  if (RONIN_MODEL_SYMBOLS.QUERY in objectValue) {
+    return {
+      type: 'query',
+      value: objectValue[RONIN_MODEL_SYMBOLS.QUERY],
+    };
+  }
+
+  if (RONIN_MODEL_SYMBOLS.EXPRESSION in objectValue) {
+    return {
+      type: 'expression',
+      value: objectValue[RONIN_MODEL_SYMBOLS.EXPRESSION],
+    };
+  }
+
+  return null;
+};
+
+/**
  * Finds all string values that match a given pattern in an object. If needed, it also
  * replaces them.
  *
@@ -256,11 +299,12 @@ type NestedObject = {
 export const flatten = (obj: NestedObject, prefix = '', res: NestedObject = {}) => {
   for (const key in obj) {
     const path = prefix ? `${prefix}.${key}` : key;
+    const value = obj[key];
 
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      flatten(obj[key] as NestedObject, path, res);
+    if (typeof value === 'object' && value !== null && !getSymbol(value)) {
+      flatten(value as NestedObject, path, res);
     } else {
-      res[path] = obj[key];
+      res[path] = value;
     }
   }
   return res;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -38,7 +38,7 @@ export const RONIN_MODEL_SYMBOLS = {
  * A regular expression for matching the symbol that represents a field of a model.
  */
 export const RONIN_MODEL_FIELD_REGEX = new RegExp(
-  `${RONIN_MODEL_SYMBOLS.FIELD}[_a-zA-Z0-9]+`,
+  `${RONIN_MODEL_SYMBOLS.FIELD}[_a-zA-Z0-9.]+`,
   'g',
 );
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,9 +33,7 @@ export const compileQueryInput = (
   // be provided as values.
   statementParams: Array<unknown> | null,
   options?: {
-    /**
-     * Whether the query should explicitly return records. Defaults to `true`.
-     */
+    /** Whether the query should explicitly return records. Defaults to `true`. */
     returning?: boolean;
     /**
      * If the query is contained within another query, this option should be set to the
@@ -43,6 +41,8 @@ export const compileQueryInput = (
      * the parent model in the nested query (the current query).
      */
     parentModel?: Model;
+    /** Alias column names that are duplicated when joining multiple tables. */
+    expandColumns?: boolean;
   },
 ): { dependencies: Array<Statement>; main: Statement } => {
   // A list of write statements that are required to be executed before the main read
@@ -85,10 +85,15 @@ export const compileQueryInput = (
   }
 
   // A list of columns that should be selected when querying records.
-  const { columns, isJoining } = handleSelecting(model, statementParams, {
-    selecting: instructions?.selecting,
-    including: instructions?.including,
-  });
+  const { columns, isJoining } = handleSelecting(
+    model,
+    statementParams,
+    {
+      selecting: instructions?.selecting,
+      including: instructions?.including,
+    },
+    options,
+  );
 
   let statement = '';
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,6 +86,7 @@ export const compileQueryInput = (
 
   // A list of columns that should be selected when querying records.
   const { columns, isJoining } = handleSelecting(
+    models,
     model,
     statementParams,
     {

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -24,14 +24,11 @@ import {
   convertToCamelCase,
   convertToSnakeCase,
   findInObject,
+  getSymbol,
   splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
-import {
-  getSymbol,
-  parseFieldExpression,
-  prepareStatementValue,
-} from '@/src/utils/statement';
+import { parseFieldExpression, prepareStatementValue } from '@/src/utils/statement';
 import title from 'title';
 
 /**

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -10,6 +10,7 @@ import {
   RONIN_MODEL_FIELD_REGEX,
   RONIN_MODEL_SYMBOLS,
   RoninError,
+  getSymbol,
   isObject,
 } from '@/src/utils/helpers';
 
@@ -401,47 +402,4 @@ export const formatIdentifiers = (
     ...queryInstructions,
     [type]: newNestedInstructions,
   } as Instructions & SetInstructions;
-};
-
-/**
- * Checks if the provided value contains a RONIN model symbol (a represenation of a
- * particular entity inside a query, such as an expression or a sub query) and returns
- * its type and value.
- *
- * @param value - The value that should be checked.
- *
- * @returns The type and value of the symbol, if the provided value contains one.
- */
-export const getSymbol = (
-  value: unknown,
-):
-  | {
-      type: 'query';
-      value: Query;
-    }
-  | {
-      type: 'expression';
-      value: string;
-    }
-  | null => {
-  if (!isObject(value)) return null;
-  const objectValue = value as
-    | Record<typeof RONIN_MODEL_SYMBOLS.QUERY, Query>
-    | Record<typeof RONIN_MODEL_SYMBOLS.EXPRESSION, string>;
-
-  if (RONIN_MODEL_SYMBOLS.QUERY in objectValue) {
-    return {
-      type: 'query',
-      value: objectValue[RONIN_MODEL_SYMBOLS.QUERY],
-    };
-  }
-
-  if (RONIN_MODEL_SYMBOLS.EXPRESSION in objectValue) {
-    return {
-      type: 'expression',
-      value: objectValue[RONIN_MODEL_SYMBOLS.EXPRESSION],
-    };
-  }
-
-  return null;
 };

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -100,7 +100,7 @@ test('expand column names', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ("id") as "including_account.id", ("ronin".locked) as "including_account.ronin.locked", ("ronin".createdAt) as "including_account.ronin.createdAt", ("ronin".createdBy) as "including_account.ronin.createdBy", ("ronin".updatedAt) as "including_account.ronin.updatedAt", ("ronin".updatedBy) as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT *, "including_account"."id" as "including_account.id", "including_account"."ronin".locked as "including_account.ronin.locked", "including_account"."ronin".createdAt as "including_account.ronin.createdAt", "including_account"."ronin".createdBy as "including_account.ronin.createdBy", "including_account"."ronin".updatedAt as "including_account.ronin.updatedAt", "including_account"."ronin".updatedBy as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
 import { queryEphemeralDatabase } from '@/fixtures/utils';
-import { type Model, type Query, Transaction } from '@/src/index';
+import { type Model, type Query, RONIN_MODEL_SYMBOLS, Transaction } from '@/src/index';
 import type { SingleRecordResult } from '@/src/types/result';
 
-test('inline statement values', async () => {
+test('inline statement parameters', async () => {
   const queries: Array<Query> = [
     {
       add: {
@@ -50,4 +50,64 @@ test('inline statement values', async () => {
     handle: 'elaine',
     emails: ['test@site.co', 'elaine@site.com'],
   });
+});
+
+test('expand column names', () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        view: {
+          including: {
+            team: {
+              [RONIN_MODEL_SYMBOLS.QUERY]: {
+                get: {
+                  team: {
+                    with: {
+                      handle: {
+                        [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT}label`,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'team',
+      fields: [
+        {
+          slug: 'handle',
+          type: 'string',
+        },
+      ],
+    },
+    {
+      slug: 'view',
+      fields: [
+        {
+          slug: 'label',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, {
+    models,
+    expandColumns: true
+  });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT * FROM "views" LEFT JOIN "teams" as including_team ON ("including_team"."handle" = "views"."label") LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
 });

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -100,7 +100,7 @@ test('expand column names', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT *, ("id") as "including_account.id", ("ronin".locked) as "including_account.ronin.locked", ("ronin".createdAt) as "including_account.ronin.createdAt", ("ronin".createdBy) as "including_account.ronin.createdBy", ("ronin".updatedAt) as "including_account.ronin.updatedAt", ("ronin".updatedBy) as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -100,7 +100,7 @@ test('expand column names', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, "including_account"."id" as "including_account.id", "including_account"."ronin".locked as "including_account.ronin.locked", "including_account"."ronin".createdAt as "including_account.ronin.createdAt", "including_account"."ronin".createdBy as "including_account.ronin.createdBy", "including_account"."ronin".updatedAt as "including_account.ronin.updatedAt", "including_account"."ronin".updatedBy as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT *, "including_account"."id" as "including_account.id", "including_account"."ronin.locked" as "including_account.ronin.locked", "including_account"."ronin.createdAt" as "including_account.ronin.createdAt", "including_account"."ronin.createdBy" as "including_account.ronin.createdBy", "including_account"."ronin.updatedAt" as "including_account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'bun:test';
 import { queryEphemeralDatabase } from '@/fixtures/utils';
-import { type Model, type Query, RONIN_MODEL_SYMBOLS, Transaction } from '@/src/index';
+import { type Model, type Query, Transaction } from '@/src/index';
 import type { SingleRecordResult } from '@/src/types/result';
+import { RONIN_MODEL_SYMBOLS } from '@/src/utils/helpers';
 
 test('inline statement parameters', async () => {
   const queries: Array<Query> = [
@@ -56,15 +57,15 @@ test('expand column names', () => {
   const queries: Array<Query> = [
     {
       get: {
-        view: {
+        member: {
           including: {
-            team: {
+            account: {
               [RONIN_MODEL_SYMBOLS.QUERY]: {
                 get: {
-                  team: {
+                  account: {
                     with: {
-                      handle: {
-                        [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT}label`,
+                      id: {
+                        [RONIN_MODEL_SYMBOLS.EXPRESSION]: `${RONIN_MODEL_SYMBOLS.FIELD_PARENT}account`,
                       },
                     },
                   },
@@ -79,19 +80,13 @@ test('expand column names', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'team',
-      fields: [
-        {
-          slug: 'handle',
-          type: 'string',
-        },
-      ],
+      slug: 'account',
     },
     {
-      slug: 'view',
+      slug: 'member',
       fields: [
         {
-          slug: 'label',
+          slug: 'account',
           type: 'string',
         },
       ],
@@ -100,12 +95,12 @@ test('expand column names', () => {
 
   const transaction = new Transaction(queries, {
     models,
-    expandColumns: true
+    expandColumns: true,
   });
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "views" LEFT JOIN "teams" as including_team ON ("including_team"."handle" = "views"."label") LIMIT 1`,
+      statement: `SELECT * FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },


### PR DESCRIPTION
This option was already documented in https://github.com/ronin-co/compiler/pull/58 (check out the readme) and allows for optionally aliasing columns that are duplicated between multiple joined tables.

This is a prerequisite of using `bun:sqlite`, because that particular SQLite driver does not allow for natively expanding column names, which most other SQLite drivers that return objects do.