### PR TITLE
Added support for joins in output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once the RONIN queries have been compiled down to SQL statements, the statements
 executed and their results can be formatted by the compiler as well:
 
 ```typescript
-// Passing `rawResults` (rows being of arrays of values) provided by the database
+// Passing `rawResults` (rows being of arrays of values) provided by the database (ideal)
 const results: Array<Result> = transaction.formatResults(rawResults);
 
 // Passing `objectResults` (rows being of objects) provided by a driver

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RONIN Compiler
 
-This package compiles [RONIN queries](https://ronin.co/docs/queries) to SQL statements.
+This package compiles [RONIN queries](https://ronin.co/docs/queries) to SQLite statements.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ new Transaction(queries, {
   //
   // If the driver being used instead returns an object for every row, the driver must
   // ensure the uniqueness of every key in that object, which means prefixing duplicated
-  // column names with the name of the respective table, if multiple tables are joined.
+  // column names with the name of the respective table, if multiple tables are joined
+  // (example for an object key: "table_name.column_name").
   //
   // Drivers that return objects for rows offer this behavior as an option that is
   // usually called "expand columns". If the driver being used does not offer such an
   // option, you can instead activate the option in the compiler, which results in longer
-  // SQL statements because any duplicated column name is aliased.
+  // SQL statements because all column names are aliased.
   expandColumns: true
 });
 ```

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Once the RONIN queries have been compiled down to SQL statements, the statements
 executed and their results can be formatted by the compiler as well:
 
 ```typescript
-// `rows` are provided by the database engine
+// Passing `rawResults` (rows being of arrays of values) provided by the database
+const results: Array<Result> = transaction.formatResults(rawResults);
 
-const results: Array<Result> = transaction.formatResults(rawResults, false);
+// Passing `objectResults` (rows being of objects) provided by a driver
+const results: Array<Result> = transaction.formatResults(objectResults, false);
 ```
 
 #### Root Model

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ executed and their results can be formatted by the compiler as well:
 ```typescript
 // `rows` are provided by the database engine
 
-const results: Array<Result> = transaction.prepareResults(rows);
+const results: Array<Result> = transaction.formatResults(rawResults, false);
 ```
 
 #### Root Model

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RONIN Compiler
 
-This package compiles [RONIN queries](https://ronin.co/docs/queries) to SQLite statements.
+This package compiles [RONIN queries](https://ronin.co/docs/queries) to [SQLite](https://www.sqlite.org) statements.
 
 ## Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,8 @@ class Transaction {
     return expand(record) as NativeRecord;
   }
 
-  prepareResults(results: Array<Array<RawRow>>, raw?: true): Array<Result>;
-  prepareResults(results: Array<Array<ObjectRow>>, raw?: false): Array<Result>;
+  formatResults(results: Array<Array<RawRow>>, raw?: true): Array<Result>;
+  formatResults(results: Array<Array<ObjectRow>>, raw?: false): Array<Result>;
 
   /**
    * Format the results returned from the database into RONIN records.
@@ -145,9 +145,9 @@ class Transaction {
    * @returns A list of formatted RONIN results, where each result is either a single
    * RONIN record, an array of RONIN records, or a count result.
    */
-  prepareResults(
+  formatResults(
     results: Array<Array<RawRow>> | Array<Array<ObjectRow>>,
-    raw = false,
+    raw = true,
   ): Array<Result> {
     // Filter out results whose statements are not expected to return any data.
     const relevantResults = results.filter((_, index) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,8 @@ class Transaction {
     return expand(record) as NativeRecord;
   }
 
-  // prepareResults: (results: Array<Array<RawRow>>, raw?: true) => Array<Result>;
-  // prepareResults: (results: Array<Array<ObjectRow>>, raw?: false) => Array<Result>;
+  prepareResults(results: Array<Array<RawRow>>, raw?: true): Array<Result>;
+  prepareResults(results: Array<Array<ObjectRow>>, raw?: false): Array<Result>;
 
   /**
    * Format the results returned from the database into RONIN records.

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ class Transaction {
     });
 
     // If the provided results are raw (rows being arrays of values, which is the most
-    // ideal format in terrms of performance, since the driver doesn't need to format
+    // ideal format in terms of performance, since the driver doesn't need to format
     // the rows in that case), we can already continue processing them further.
     //
     // If the provided results were already formatted by the driver (rows being objects),

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,13 @@ class Transaction {
     for (let index = 0; index < row.length; index++) {
       const value = row[index];
       const field = fields[index];
+
+      let newValue = value;
+
+      if (field.type === 'json') {
+        newValue = JSON.parse(value as string);
+      }
+
       const parentFieldSlug = (field as ModelField & { parentField?: string })
         .parentField;
 
@@ -115,16 +122,12 @@ class Transaction {
       if (parentFieldSlug) {
         const parentValue = record[parentFieldSlug];
         if (!parentValue || typeof parentValue === 'string') record[parentFieldSlug] = {};
-        (record[parentFieldSlug] as Record<string, unknown>)[field.slug] = value;
-        continue;
+        (record[parentFieldSlug] as Record<string, unknown>)[field.slug] = newValue;
       }
-
-      if (field.type === 'json') {
-        record[field.slug] = JSON.parse(value as string);
-        continue;
+      // Otherwise we can just assign the value directly to the record.
+      else {
+        record[field.slug] = newValue;
       }
-
-      record[field.slug] = value;
     }
 
     return expand(record) as NativeRecord;

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,8 @@ class Transaction {
       const value = row[index];
       const field = fields[index];
 
+      let newSlug = field.slug;
       let newValue = value;
-
-      if (field.type === 'json') {
-        newValue = JSON.parse(value as string);
-      }
 
       const parentFieldSlug = (field as ModelField & { parentField?: string })
         .parentField;
@@ -120,14 +117,14 @@ class Transaction {
       // parent field if it doesn't exist yet, and then assign the value of the nested
       // field to that newly created object.
       if (parentFieldSlug) {
-        const parentValue = record[parentFieldSlug];
-        if (!parentValue || typeof parentValue === 'string') record[parentFieldSlug] = {};
-        (record[parentFieldSlug] as Record<string, unknown>)[field.slug] = newValue;
+        newSlug = `${parentFieldSlug}.${field.slug}`;
       }
-      // Otherwise we can just assign the value directly to the record.
-      else {
-        record[field.slug] = newValue;
+
+      if (field.type === 'json') {
+        newValue = JSON.parse(value as string);
       }
+
+      record[newSlug] = newValue;
     }
 
     return expand(record) as NativeRecord;

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -1,7 +1,7 @@
 import type { WithFilters } from '@/src/instructions/with';
 import type { Model } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
-import { getSymbol, splitQuery } from '@/src/utils/helpers';
+import { composeIncludedTableAlias, getSymbol, splitQuery } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
 import { getModelBySlug } from '@/src/utils/model';
 import { composeConditions } from '@/src/utils/statement';
@@ -50,7 +50,7 @@ export const handleIncluding = (
     let joinType: 'LEFT' | 'CROSS' = 'LEFT';
     let relatedTableSelector = `"${relatedModel.table}"`;
 
-    const tableAlias = `including_${ephemeralFieldSlug}`;
+    const tableAlias = composeIncludedTableAlias(ephemeralFieldSlug);
     const single = queryModel !== relatedModel.pluralSlug;
 
     // If no `with` query instruction is provided, we want to perform a CROSS

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -49,8 +49,8 @@ export const handleSelecting = (
     const flatObject = flatten(instructions.including);
 
     // Clear the object so we can set fresh keys further below. Clearing the object and
-    // setting keys is faster than constructing an entirely new object from the entries
-    // of the old object.
+    // setting keys is faster than constructing an entirely new object from arrays of
+    // values that were previously mapped over.
     instructions.including = {};
 
     // Filter out any fields whose value is a sub query, as those fields are instead
@@ -120,7 +120,7 @@ export const handleSelecting = (
       ? { ...model, tableAlias: model.tableAlias || model.table }
       : model;
 
-    // Reset the list of loaded fields.
+    // The model fields that were selected by the root query.
     const selectedFields: Array<ModelField> = [];
 
     statement = instructions.selecting

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -64,22 +64,22 @@ export const handleSelecting = (
       if (symbol?.type === 'query') {
         isJoining = true;
 
-        // If the column names should be expanded, that means we need to alias all
-        // columns of the joined table to avoid conflicts with the root table.
-        if (options?.expandColumns) {
-          const { queryModel, queryInstructions } = splitQuery(symbol.value);
-          const subQueryModel = getModelBySlug(models, queryModel);
-          const tableName = composeIncludedTableAlias(key);
+        const { queryModel, queryInstructions } = splitQuery(symbol.value);
+        const subQueryModel = getModelBySlug(models, queryModel);
+        const tableName = composeIncludedTableAlias(key);
 
-          const queryModelFields = queryInstructions?.selecting
-            ? subQueryModel.fields.filter((field) => {
-                return queryInstructions.selecting?.includes(field.slug);
-              })
-            : subQueryModel.fields;
+        const queryModelFields = queryInstructions?.selecting
+          ? subQueryModel.fields.filter((field) => {
+              return queryInstructions.selecting?.includes(field.slug);
+            })
+          : subQueryModel.fields;
 
-          for (const field of queryModelFields) {
-            loadedFields.push({ ...field, parentField: key } as unknown as ModelField);
+        for (const field of queryModelFields) {
+          loadedFields.push({ ...field, parentField: key } as unknown as ModelField);
 
+          // If the column names should be expanded, that means we need to alias all
+          // columns of the joined table to avoid conflicts with the root table.
+          if (options?.expandColumns) {
             const newValue = parseFieldExpression(
               { ...subQueryModel, tableAlias: tableName },
               'including',

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -1,6 +1,12 @@
 import type { Model, ModelField } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
-import { QUERY_SYMBOLS, flatten, getSymbol, splitQuery } from '@/src/utils/helpers';
+import {
+  QUERY_SYMBOLS,
+  composeIncludedTableAlias,
+  flatten,
+  getSymbol,
+  splitQuery,
+} from '@/src/utils/helpers';
 import { getFieldFromModel, getModelBySlug } from '@/src/utils/model';
 import { parseFieldExpression, prepareStatementValue } from '@/src/utils/statement';
 
@@ -63,7 +69,7 @@ export const handleSelecting = (
         if (options?.expandColumns) {
           const { queryModel, queryInstructions } = splitQuery(symbol.value);
           const subQueryModel = getModelBySlug(models, queryModel);
-          const tableName = `including_${key}`;
+          const tableName = composeIncludedTableAlias(key);
 
           const queryModelFields = queryInstructions?.selecting
             ? subQueryModel.fields.filter((field) => {

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -72,7 +72,6 @@ export const handleSelecting = (
 
           const duplicatedFields = queryModel.fields
             .filter((field) => {
-              if (field.type === 'group') return null;
               return model.fields.some((modelField) => modelField.slug === field.slug);
             })
             .filter((item) => item !== null);

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -164,9 +164,9 @@ export const handleTo = (
   // direct link.
   for (const fieldSlug in toInstruction) {
     const fieldValue = toInstruction[fieldSlug];
-    const fieldDetails = getFieldFromModel(model, fieldSlug, 'to');
+    const fieldDetails = getFieldFromModel(model, fieldSlug, 'to', false);
 
-    if (fieldDetails.field.type === 'link' && fieldDetails.field.kind === 'many') {
+    if (fieldDetails?.field.type === 'link' && fieldDetails.field.kind === 'many') {
       // Remove the field from the `to` instruction as it will be handled using
       // separate queries.
       delete toInstruction[fieldSlug];

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -53,7 +53,7 @@ type ModelFieldBasics = {
 };
 
 type ModelFieldNormal = ModelFieldBasics & {
-  type: 'string' | 'number' | 'boolean' | 'date' | 'json' | 'group';
+  type: 'string' | 'number' | 'boolean' | 'date' | 'json';
 };
 
 export type ModelFieldReferenceAction =

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,4 +1,7 @@
-export type Row = Record<string, unknown>;
+export type RawRow = Array<unknown>;
+export type ObjectRow = Record<string, unknown>;
+
+export type Row = RawRow | ObjectRow;
 
 export type NativeRecord = Record<string, unknown> & {
   id: string;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -334,14 +334,19 @@ export const omit = <T extends Record<string, unknown>, K extends keyof T>(
  *
  * @returns The expanded object.
  */
-export const expand = (obj: NestedObject) => {
+export const expand = (obj: NestedObject): NestedObject => {
   return Object.entries(obj).reduce((res, [key, val]) => {
     key
       .split('.')
       .reduce((acc: NestedObject, part: string, i: number, arr: Array<string>) => {
-        acc[part] = i === arr.length - 1 ? val : acc[part] || {};
+        if (i === arr.length - 1) {
+          acc[part] = val;
+        } else {
+          acc[part] =
+            typeof acc[part] === 'object' && acc[part] !== null ? acc[part] : {};
+        }
         return acc[part] as NestedObject;
-      }, res);
+      }, res as NestedObject);
     return res;
   }, {});
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,6 +42,16 @@ export const RONIN_MODEL_FIELD_REGEX = new RegExp(
   'g',
 );
 
+/**
+ * Composes an alias for a table that should be joined into the root table.
+ *
+ * @param fieldSlug - The field on the root record(s) onto which the joined records
+ * should eventually be mounted.
+ *
+ * @returns An alias for the joined table.
+ */
+export const composeIncludedTableAlias = (fieldSlug: string) => `including_${fieldSlug}`;
+
 type RoninErrorCode =
   | 'MODEL_NOT_FOUND'
   | 'FIELD_NOT_FOUND'

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -317,11 +317,6 @@ export const SYSTEM_FIELDS: Array<ModelField> = [
     displayAs: 'single-line',
   },
   {
-    name: 'RONIN',
-    type: 'group',
-    slug: 'ronin',
-  },
-  {
     name: 'RONIN - Locked',
     type: 'boolean',
     slug: 'ronin.locked',
@@ -375,7 +370,6 @@ export const ROOT_MODEL: PartialModel = {
     { slug: 'idPrefix', type: 'string' },
     { slug: 'table', type: 'string' },
 
-    { slug: 'identifiers', type: 'group' },
     { slug: 'identifiers.name', type: 'string' },
     { slug: 'identifiers.slug', type: 'string' },
 
@@ -570,8 +564,6 @@ const getFieldStatement = (
   model: Model,
   field: ModelField,
 ): string | null => {
-  if (field.type === 'group') return null;
-
   let statement = `"${field.slug}" ${typesInSQLite[field.type]}`;
 
   if (field.slug === 'id') statement += ' PRIMARY KEY';

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -104,6 +104,27 @@ const getFieldSelector = (
   return `${tablePrefix}"${fieldPath}"`;
 };
 
+export function getFieldFromModel(
+  model: Model,
+  fieldPath: string,
+  instructionName: QueryInstructionType,
+  shouldThrow?: true,
+): { field: ModelField; fieldSelector: string };
+
+export function getFieldFromModel(
+  model: Model,
+  fieldPath: string,
+  instructionName: QueryInstructionType,
+  shouldThrow?: false,
+): { field: ModelField; fieldSelector: string } | null;
+
+export function getFieldFromModel(
+  model: Model,
+  fieldPath: string,
+  instructionName: QueryInstructionType,
+  shouldThrow: boolean,
+): { field: ModelField; fieldSelector: string } | null;
+
 /**
  * Obtains a field from a given model using its path.
  *
@@ -111,14 +132,16 @@ const getFieldSelector = (
  * @param fieldPath - The path of the field to retrieve. Supports dot notation for
  * accessing nested fields.
  * @param instructionName - The name of the query instruction that is being used.
+ * @param shouldThrow - Whether to throw an error if the field is not found.
  *
  * @returns The requested field of the model, and its SQL selector.
  */
-export const getFieldFromModel = (
+export function getFieldFromModel(
   model: Model,
   fieldPath: string,
   instructionName: QueryInstructionType,
-): { field: ModelField; fieldSelector: string } => {
+  shouldThrow = true,
+): { field: ModelField; fieldSelector: string } | null {
   const errorPrefix = `Field "${fieldPath}" defined for \`${instructionName}\``;
   const modelFields = model.fields || [];
 
@@ -143,17 +166,21 @@ export const getFieldFromModel = (
   modelField = modelFields.find((field) => field.slug === fieldPath);
 
   if (!modelField) {
-    throw new RoninError({
-      message: `${errorPrefix} does not exist in model "${model.name}".`,
-      code: 'FIELD_NOT_FOUND',
-      field: fieldPath,
-      queries: null,
-    });
+    if (shouldThrow) {
+      throw new RoninError({
+        message: `${errorPrefix} does not exist in model "${model.name}".`,
+        code: 'FIELD_NOT_FOUND',
+        field: fieldPath,
+        queries: null,
+      });
+    }
+
+    return null;
   }
 
   const fieldSelector = getFieldSelector(model, modelField, fieldPath, instructionName);
   return { field: modelField, fieldSelector };
-};
+}
 
 /**
  * Converts a slug to a readable name by splitting it on uppercase characters

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -273,10 +273,10 @@ export const composeConditions = (
 
         let recordTarget: WithValue | Record<typeof QUERY_SYMBOLS.QUERY, Query>;
 
-        // If only a single key is present, and it's "id", then we can simplify the query a
-        // bit in favor of performance, because the stored value of a link field in SQLite
-        // is always the ID of the linked record. That means we don't need to join the
-        // destination table, and we can just perform a string assertion.
+        // If only a single key is present, and it's "id", then we can simplify the query
+        // a bit in favor of performance, because the stored value of a link field in
+        // SQLite is always the ID of the linked record. That means we don't need to join
+        // the destination table, and we can just perform a string assertion.
         if (keys.length === 1 && keys[0] === 'id') {
           // This can be either a string or an object with conditions such as `being`.
           recordTarget = values[0];

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -234,64 +234,78 @@ export const composeConditions = (
   // potential object value in a special way, instead of just iterating over the nested
   // fields and trying to assert the column for each one.
   if (options.fieldSlug) {
-    const fieldDetails = getFieldFromModel(model, options.fieldSlug, instructionName);
+    const childField = model.fields.some(({ slug }) => {
+      return slug.includes('.') && slug.split('.')[0] === options.fieldSlug;
+    });
 
-    const { field: modelField } = fieldDetails;
+    // If a nested field exists within the model that is nested under the field slug that
+    // was provided, we know that the current field is a parent field, which means it
+    // exists on records as a key, but not as a real field inside the model. That means
+    // we can just continue parsing its contents.
+    if (!childField) {
+      const fieldDetails = getFieldFromModel(model, options.fieldSlug, instructionName);
 
-    // If the `to` instruction is used, JSON should be written as-is.
-    const consumeJSON = modelField.type === 'json' && instructionName === 'to';
+      const { field: modelField } = fieldDetails || {};
 
-    if (!(isObject(value) || Array.isArray(value)) || getSymbol(value) || consumeJSON) {
-      return composeFieldValues(
-        models,
-        model,
-        statementParams,
-        instructionName,
-        value as WithValue,
-        { ...options, fieldSlug: options.fieldSlug as string },
-      );
-    }
+      // If the `to` instruction is used, JSON should be written as-is.
+      const consumeJSON = modelField?.type === 'json' && instructionName === 'to';
 
-    if (modelField.type === 'link' && isNested) {
-      // `value` is asserted to be an object using `isObject` above, so we can safely
-      // cast it here. The type is not being inferred automatically.
-      const keys = Object.keys(value as object);
-      const values = Object.values(value as object);
-
-      let recordTarget: WithValue | Record<typeof QUERY_SYMBOLS.QUERY, Query>;
-
-      // If only a single key is present, and it's "id", then we can simplify the query a
-      // bit in favor of performance, because the stored value of a link field in SQLite
-      // is always the ID of the linked record. That means we don't need to join the
-      // destination table, and we can just perform a string assertion.
-      if (keys.length === 1 && keys[0] === 'id') {
-        // This can be either a string or an object with conditions such as `being`.
-        recordTarget = values[0];
-      } else {
-        const relatedModel = getModelBySlug(models, modelField.target);
-
-        const subQuery: Query = {
-          get: {
-            [relatedModel.slug]: {
-              with: value as WithInstruction,
-              selecting: ['id'],
-            },
-          },
-        };
-
-        recordTarget = {
-          [QUERY_SYMBOLS.QUERY]: subQuery,
-        };
+      if (
+        (modelField && !(isObject(value) || Array.isArray(value))) ||
+        getSymbol(value) ||
+        consumeJSON
+      ) {
+        return composeFieldValues(
+          models,
+          model,
+          statementParams,
+          instructionName,
+          value as WithValue,
+          { ...options, fieldSlug: options.fieldSlug as string },
+        );
       }
 
-      return composeConditions(
-        models,
-        model,
-        statementParams,
-        instructionName,
-        recordTarget,
-        options,
-      );
+      if (modelField?.type === 'link' && isNested) {
+        // `value` is asserted to be an object using `isObject` above, so we can safely
+        // cast it here. The type is not being inferred automatically.
+        const keys = Object.keys(value as object);
+        const values = Object.values(value as object);
+
+        let recordTarget: WithValue | Record<typeof QUERY_SYMBOLS.QUERY, Query>;
+
+        // If only a single key is present, and it's "id", then we can simplify the query a
+        // bit in favor of performance, because the stored value of a link field in SQLite
+        // is always the ID of the linked record. That means we don't need to join the
+        // destination table, and we can just perform a string assertion.
+        if (keys.length === 1 && keys[0] === 'id') {
+          // This can be either a string or an object with conditions such as `being`.
+          recordTarget = values[0];
+        } else {
+          const relatedModel = getModelBySlug(models, modelField.target);
+
+          const subQuery: Query = {
+            get: {
+              [relatedModel.slug]: {
+                with: value as WithInstruction,
+                selecting: ['id'],
+              },
+            },
+          };
+
+          recordTarget = {
+            [QUERY_SYMBOLS.QUERY]: subQuery,
+          };
+        }
+
+        return composeConditions(
+          models,
+          model,
+          statementParams,
+          instructionName,
+          recordTarget,
+          options,
+        );
+      }
     }
   }
 

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -30,8 +30,8 @@ test('get multiple records limited to amount', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toHaveLength(2);
   expect(result.moreBefore).toBeUndefined();
@@ -79,8 +79,8 @@ test('get multiple records limited to amount ordered by link field', async () =>
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toHaveLength(2);
   expect(result.moreBefore).toBeUndefined();

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -39,8 +39,8 @@ test('get multiple records ordered by field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toMatchObject([
     {
@@ -95,8 +95,8 @@ test('get multiple records ordered by expression', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toMatchObject([
     {
@@ -149,8 +149,8 @@ test('get multiple records ordered by multiple fields', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toMatchObject([
     {

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -30,8 +30,8 @@ test('get single record with specific field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
     id: expect.stringMatching(RECORD_ID_REGEX),
@@ -71,8 +71,8 @@ test('get single record with specific fields', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
     id: expect.stringMatching(RECORD_ID_REGEX),

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -475,7 +475,7 @@ test('set single record to new json field with object', async () => {
   });
 });
 
-test('set single record to new grouped string field', async () => {
+test('set single record to new nested string field', async () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -497,10 +497,6 @@ test('set single record to new grouped string field', async () => {
     {
       slug: 'team',
       fields: [
-        {
-          slug: 'billing',
-          type: 'group',
-        },
         {
           slug: 'billing.currency',
           type: 'string',
@@ -529,7 +525,7 @@ test('set single record to new grouped string field', async () => {
   expect((result.record?.billing as { currency: string })?.currency).toBe('USD');
 });
 
-test('set single record to new grouped link field', async () => {
+test('set single record to new nested link field', async () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -562,10 +558,6 @@ test('set single record to new grouped link field', async () => {
     {
       slug: 'team',
       fields: [
-        {
-          slug: 'billing',
-          type: 'group',
-        },
         {
           slug: 'billing.manager',
           type: 'link',
@@ -602,7 +594,7 @@ test('set single record to new grouped link field', async () => {
   expect((result.record?.billing as { manager: string })?.manager).toBe(targetRecord.id);
 });
 
-test('set single record to new grouped json field', async () => {
+test('set single record to new nested json field', async () => {
   const queries: Array<Query> = [
     {
       set: {
@@ -624,10 +616,6 @@ test('set single record to new grouped json field', async () => {
     {
       slug: 'team',
       fields: [
-        {
-          slug: 'billing',
-          type: 'group',
-        },
         {
           slug: 'billing.invoiceRecipients',
           type: 'json',

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -47,8 +47,8 @@ test('set single record to new string field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBe('mia');
 });
@@ -101,8 +101,8 @@ test('set single record to new string field with expression referencing fields',
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBe('elainejones');
 });
@@ -161,7 +161,7 @@ test('set single record to new one-cardinality link field', async () => {
     },
   ]);
 
-  const [[targetRecord], ...rows] = await queryEphemeralDatabase(models, [
+  const [[targetRecord], ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
       params: [],
@@ -169,7 +169,7 @@ test('set single record to new one-cardinality link field', async () => {
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.account).toBe(targetRecord.id);
 });
@@ -234,8 +234,8 @@ test('set single record to new many-cardinality link field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.followers).toBeUndefined();
   expect(result.record?.ronin.updatedAt).toMatch(RECORD_TIMESTAMP_REGEX);
@@ -299,8 +299,8 @@ test('set single record to new many-cardinality link field (add)', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.followers).toBeUndefined();
   expect(result.record?.ronin.updatedAt).toMatch(RECORD_TIMESTAMP_REGEX);
@@ -358,8 +358,8 @@ test('set single record to new many-cardinality link field (remove)', async () =
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.followers).toBeUndefined();
   expect(result.record?.ronin.updatedAt).toMatch(RECORD_TIMESTAMP_REGEX);
@@ -411,8 +411,8 @@ test('set single record to new json field with array', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.emails).toEqual(['elaine@site.co', 'elaine@company.co']);
 });
@@ -466,8 +466,8 @@ test('set single record to new json field with object', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.emails).toEqual({
     site: 'elaine@site.co',
@@ -519,8 +519,8 @@ test('set single record to new nested string field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect((result.record?.billing as { currency: string })?.currency).toBe('USD');
 });
@@ -581,7 +581,7 @@ test('set single record to new nested link field', async () => {
     },
   ]);
 
-  const [[targetRecord], ...rows] = await queryEphemeralDatabase(models, [
+  const [[targetRecord], ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
       params: [],
@@ -589,7 +589,7 @@ test('set single record to new nested link field', async () => {
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect((result.record?.billing as { manager: string })?.manager).toBe(targetRecord.id);
 });
@@ -638,8 +638,8 @@ test('set single record to new nested json field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(
     (result.record?.billing as { invoiceRecipients: Array<string> })?.invoiceRecipients,
@@ -710,7 +710,7 @@ test('set single record to result of nested query', async () => {
     },
   ]);
 
-  const [[targetRecord], ...rows] = await queryEphemeralDatabase(models, [
+  const [[targetRecord], ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT lastName FROM "accounts" WHERE ("handle" = 'david') LIMIT 1`,
       params: [],
@@ -718,7 +718,7 @@ test('set single record to result of nested query', async () => {
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.name).toBe(targetRecord.lastName);
 });
@@ -771,7 +771,7 @@ test('add multiple records with nested sub query', async () => {
     },
   ]);
 
-  const [targetRecords, ...rows] = await queryEphemeralDatabase(models, [
+  const [targetRecords, ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts"`,
       params: [],
@@ -779,7 +779,7 @@ test('add multiple records with nested sub query', async () => {
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records.map(({ handle }) => ({ handle }))).toEqual(
     targetRecords.map(({ handle }) => ({ handle })),
@@ -843,8 +843,8 @@ test('add multiple records with nested sub query including additional fields', a
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toMatchObject([
     {
@@ -910,7 +910,7 @@ test('add multiple records with nested sub query and specific fields', async () 
     },
   ]);
 
-  const [targetRecords, ...rows] = await queryEphemeralDatabase(models, [
+  const [targetRecords, ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts"`,
       params: [],
@@ -918,7 +918,7 @@ test('add multiple records with nested sub query and specific fields', async () 
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records.map(({ handle }) => ({ handle }))).toEqual(
     targetRecords.map(({ handle }) => ({ handle })),
@@ -964,7 +964,7 @@ test('add multiple records with nested sub query and specific meta fields', asyn
     },
   ]);
 
-  const [targetRecords, ...rows] = await queryEphemeralDatabase(models, [
+  const [targetRecords, ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts"`,
       params: [],
@@ -972,7 +972,7 @@ test('add multiple records with nested sub query and specific meta fields', asyn
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(
     result.records.map(({ ronin: { updatedAt } }) => ({ ronin: { updatedAt } })),

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -40,8 +40,8 @@ test('get single record with field being value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBe('elaine');
 });
@@ -83,8 +83,8 @@ test('get single record with field not being value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).not.toBe('elaine');
 });
@@ -126,8 +126,8 @@ test('get single record with field not being empty', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).not.toBeNull();
 });
@@ -169,8 +169,8 @@ test('get single record with field starting with value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toStartWith('el');
 });
@@ -212,8 +212,8 @@ test('get single record with field not starting with value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).not.toStartWith('el');
 });
@@ -255,8 +255,8 @@ test('get single record with field ending with value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toEndWith('ne');
 });
@@ -298,8 +298,8 @@ test('get single record with field not ending with value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).not.toEndWith('ne');
 });
@@ -341,8 +341,8 @@ test('get single record with field containing value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toContain('ain');
 });
@@ -384,8 +384,8 @@ test('get single record with field not containing value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).not.toContain('ain');
 });
@@ -427,8 +427,8 @@ test('get single record with field greater than value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.position).toBeGreaterThan(1);
 });
@@ -470,8 +470,8 @@ test('get single record with field greater or equal to value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.position).toBeGreaterThanOrEqual(2);
 });
@@ -513,8 +513,8 @@ test('get single record with field less than value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.position).toBeLessThan(3);
 });
@@ -556,8 +556,8 @@ test('get single record with field less or equal to value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.position).toBeLessThanOrEqual(3);
 });
@@ -607,8 +607,8 @@ test('get single record with multiple fields being value', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBe('elaine');
   expect(result.record?.firstName).toBe('Elaine');
@@ -662,7 +662,7 @@ test('get single record with link field', async () => {
     },
   ]);
 
-  const [[targetRecord], ...rows] = await queryEphemeralDatabase(models, [
+  const [[targetRecord], ...rawResults] = await queryEphemeralDatabase(models, [
     {
       statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
       params: [],
@@ -670,7 +670,7 @@ test('get single record with link field', async () => {
     ...transaction.statements,
   ]);
 
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.account).toBe(targetRecord.id);
 });
@@ -716,8 +716,8 @@ test('get single record with link field and id', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.account).toBe('acc_39h8fhe98hefah9j');
 });
@@ -765,8 +765,8 @@ test('get single record with link field and id with condition', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.account).toBe('acc_39h8fhe98hefah9j');
 });
@@ -808,8 +808,8 @@ test('get single record with json field', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.locations).toHaveProperty('europe', 'berlin');
 });
@@ -858,8 +858,8 @@ test('get single record with one of fields', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(
     result.record?.handle === 'elaine' || result.record?.firstName === 'David',
@@ -908,8 +908,8 @@ test('get single record with one of field conditions', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBeOneOf(['elaine', 'david']);
 });
@@ -951,8 +951,8 @@ test('get single record with one of field values', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBeOneOf(['elaine', 'david']);
 });
@@ -994,8 +994,8 @@ test('get single record with one of nested field values', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect((result.record?.billing as Record<string, unknown>).currency).toBeOneOf([
     'EUR',
@@ -1043,8 +1043,8 @@ test('get single record with name identifier', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.firstName).toBe('Elaine');
 });
@@ -1089,8 +1089,8 @@ test('get single record with slug identifier', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.handle).toBe('elaine');
 });

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -957,7 +957,7 @@ test('get single record with one of field values', async () => {
   expect(result.record?.handle).toBeOneOf(['elaine', 'david']);
 });
 
-test('get single record with one of field values in group', async () => {
+test('get single record with one of nested field values', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -976,10 +976,6 @@ test('get single record with one of field values in group', async () => {
     {
       slug: 'team',
       fields: [
-        {
-          slug: 'billing',
-          type: 'group',
-        },
         {
           slug: 'billing.currency',
           type: 'string',

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -48,8 +48,8 @@ test('inline statement parameters', async () => {
   );
   expect(transaction.statements[0].params).toEqual([]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
     handle: 'elaine',
@@ -110,8 +110,8 @@ test('expand column names', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
     id: expect.stringMatching(RECORD_ID_REGEX),

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -100,13 +100,15 @@ test('expand column names', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, "including_account"."id" as "including_account.id", "including_account"."ronin.locked" as "including_account.ronin.locked", "including_account"."ronin.createdAt" as "including_account.ronin.createdAt", "including_account"."ronin.createdBy" as "including_account.ronin.createdBy", "including_account"."ronin.updatedAt" as "including_account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT "members"."id", "members"."ronin.locked", "members"."ronin.createdAt", "members"."ronin.createdBy", "members"."ronin.updatedAt", "members"."ronin.updatedBy", "members"."account", "including_account"."id" as "including_account.id", "including_account"."ronin.locked" as "including_account.ronin.locked", "including_account"."ronin.createdAt" as "including_account.ronin.createdAt", "including_account"."ronin.createdBy" as "including_account.ronin.createdBy", "including_account"."ronin.updatedAt" as "including_account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "including_account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as including_account ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },
   ]);
 
   const rows = await queryEphemeralDatabase(models, transaction.statements);
+
+  console.log(rows);
   const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
 
   console.log(result);

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'bun:test';
-import { queryEphemeralDatabase } from '@/fixtures/utils';
+import {
+  RECORD_ID_REGEX,
+  RECORD_TIMESTAMP_REGEX,
+  queryEphemeralDatabase,
+} from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
-import type { MultipleRecordResult, SingleRecordResult } from '@/src/types/result';
+import type { SingleRecordResult } from '@/src/types/result';
 import { QUERY_SYMBOLS } from '@/src/utils/helpers';
 
 test('inline statement parameters', async () => {
@@ -107,9 +111,26 @@ test('expand column names', async () => {
   ]);
 
   const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
 
-  console.log(rows);
-  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
-
-  console.log(result);
+  expect(result.record).toMatchObject({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    ronin: {
+      locked: null,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    account: {
+      id: expect.stringMatching(RECORD_ID_REGEX),
+      ronin: {
+        locked: null,
+        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        createdBy: null,
+        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        updatedBy: null,
+      },
+    },
+  });
 });

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
-import type { SingleRecordResult } from '@/src/types/result';
+import type { MultipleRecordResult, SingleRecordResult } from '@/src/types/result';
 import { QUERY_SYMBOLS } from '@/src/utils/helpers';
 
 test('inline statement parameters', async () => {
@@ -53,7 +53,7 @@ test('inline statement parameters', async () => {
   });
 });
 
-test('expand column names', () => {
+test('expand column names', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -105,4 +105,9 @@ test('expand column names', () => {
       returning: true,
     },
   ]);
+
+  const rows = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.prepareResults(rows)[0] as MultipleRecordResult;
+
+  console.log(result);
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -28,8 +28,8 @@ test('get single record', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.id).toMatch(RECORD_ID_REGEX);
 });
@@ -69,8 +69,8 @@ test('remove single record', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as SingleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
   expect(result.record?.id).toMatch(RECORD_ID_REGEX);
 });
@@ -100,8 +100,8 @@ test('count multiple records', async () => {
     },
   ]);
 
-  const rows = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.prepareResults(rows)[0] as AmountResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as AmountResult;
 
   expect(result.amount).toBeNumber();
 });


### PR DESCRIPTION
This change makes it possible for the `transaction.formatResults` method to handle results from joined tables.

Additionally, it introduces a second argument for `transaction.formatResults`, which allows for handling database driver results that are not raw (rows being arrays of values) but instead pre-formatted by the driver (rows being objects), by normalizing those before processing them:

```typescript
// Passing `rawResults` (rows being of arrays of values) provided by the database (ideal)
const results: Array<Result> = transaction.formatResults(rawResults);

// Passing `objectResults` (rows being of objects) provided by a driver
const results: Array<Result> = transaction.formatResults(objectResults, false);
```

Lastly, the change also deletes the `group` field type, in favor of inferring it from nested fields. Meaning if a field contains a period in its slug (e.g. `billing.invoiceRecipient`), it is automatically considered a nested field, and doesn't require an explicit group field (e.g. `billing`) to be created.