### PR TITLE
Assert multiple records being joined into one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,8 @@ class Transaction {
 
       if (field.type === 'json') {
         newValue = JSON.parse(value as string);
+      } else if (field.type === 'boolean') {
+        newValue = Boolean(value);
       }
 
       record[newSlug] = newValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,13 +143,8 @@ class Transaction {
           if (rows.length === 1) {
             newSlug = `${parentFieldSlug}.${field.slug}`;
           } else {
-            if (!Array.isArray(records[0][parentFieldSlug]))
-              records[0][parentFieldSlug] = [];
-
-            if (!records[0][parentFieldSlug][rowIndex]) {
-              records[0][parentFieldSlug][rowIndex] = {};
-            }
-            records[0][parentFieldSlug][rowIndex][field.slug] = newValue;
+            const fieldPath = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
+            records[0] = setProperty(records[0], fieldPath, newValue);
 
             continue;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,14 +149,13 @@ class Transaction {
           // Alternatively, if the field is nested into a parent field and more than one
           // row is available, that means multiple rows are being joined from a different
           // table, so we need to create an array as the value of the parent field, and
-          // will it with the respective joined records.
+          // fill it with the respective joined records.
           else {
             newSlug = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
             usableRowIndex = 0;
           }
         }
 
-        // setProperty(records, `[${[usableRowIndex]}].${newSlug}`, newValue);
         records[usableRowIndex] = setProperty(records[usableRowIndex], newSlug, newValue);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ class Transaction {
 
       // The query is targeting a single record.
       if (single) {
-        return { record: this.formatRow(fields, rows[0]) };
+        return { record: rows[0] ? this.formatRow(fields, rows[0]) : null };
       }
 
       const pageSize = queryInstructions?.limitedTo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,20 +137,26 @@ class Transaction {
         const parentFieldSlug = (field as ModelField & { parentField?: string })
           .parentField;
 
-        // If the field is nested into a parent field, prefix it with the slug of the parent
-        // field, which causes it to get nested into a parent object in the final record.
+        let usableRowIndex = rowIndex;
+
         if (parentFieldSlug) {
+          // If the field is nested into a parent field and only one row is available,
+          // prefix the current field with the slug of the parent field, which causes it
+          // to get nested into a parent object in the final record.
           if (rows.length === 1) {
             newSlug = `${parentFieldSlug}.${field.slug}`;
-          } else {
-            const fieldPath = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
-            records[0] = setProperty(records[0], fieldPath, newValue);
-
-            continue;
+          }
+          // Alternatively, if the field is nested into a parent field and more than one
+          // row is available, that means multiple rows are being joined from a different
+          // table, so we need to create an array as the value of the parent field, and
+          // will it with the respective joined records.
+          else {
+            newSlug = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
+            usableRowIndex = 0;
           }
         }
 
-        records[rowIndex] = setProperty(records[rowIndex], newSlug, newValue);
+        records[usableRowIndex] = setProperty(records[usableRowIndex], newSlug, newValue);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ class Transaction {
           }
         }
 
+        // setProperty(records, `[${[usableRowIndex]}].${newSlug}`, newValue);
         records[usableRowIndex] = setProperty(records[usableRowIndex], newSlug, newValue);
       }
     }

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -102,12 +102,11 @@ export const handleIncluding = (
     // Show the table name for every column in the final SQL statement. By default, it
     // doesn't show, but since we are joining multiple tables together, we need to show
     // the table name for every column, in order to avoid conflicts.
-    model.tableAlias = model.table;
+    model.tableAlias = model.tableAlias || model.table;
 
     if (joinType === 'LEFT') {
       if (!single) {
         tableSubQuery = `SELECT * FROM "${model.table}" LIMIT 1`;
-        model.tableAlias = `sub_${model.table}`;
       }
 
       const subStatement = composeConditions(

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -70,6 +70,9 @@ export const handleSelecting = (
         const tableAlias = composeIncludedTableAlias(key);
         const single = queryModel !== subQueryModel.pluralSlug;
 
+        // If multiple records are being joined and the root query only targets a single
+        // record, we need to alias the root table, because it will receive a dedicated
+        // SELECT statement in the `handleIncluding` function.
         if (!single) {
           model.tableAlias = `sub_${model.table}`;
         }

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -66,7 +66,13 @@ export const handleSelecting = (
 
         const { queryModel, queryInstructions } = splitQuery(symbol.value);
         const subQueryModel = getModelBySlug(models, queryModel);
-        const tableName = composeIncludedTableAlias(key);
+
+        const tableAlias = composeIncludedTableAlias(key);
+        const single = queryModel !== subQueryModel.pluralSlug;
+
+        if (!single) {
+          model.tableAlias = `sub_${model.table}`;
+        }
 
         const queryModelFields = queryInstructions?.selecting
           ? subQueryModel.fields.filter((field) => {
@@ -81,12 +87,12 @@ export const handleSelecting = (
           // columns of the joined table to avoid conflicts with the root table.
           if (options?.expandColumns) {
             const newValue = parseFieldExpression(
-              { ...subQueryModel, tableAlias: tableName },
+              { ...subQueryModel, tableAlias },
               'including',
               `${QUERY_SYMBOLS.FIELD}${field.slug}`,
             );
 
-            instructions.including![`${tableName}.${field.slug}`] = newValue;
+            instructions.including![`${tableAlias}.${field.slug}`] = newValue;
           }
         }
 

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -6,8 +6,11 @@ export type Row = RawRow | ObjectRow;
 export type NativeRecord = Record<string, unknown> & {
   id: string;
   ronin: {
+    locked: boolean;
     createdAt: Date;
+    createdBy: string | null;
     updatedAt: Date;
+    updatedBy: string | null;
   };
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -365,6 +365,7 @@ export const expand = (obj: NestedObject): NestedObject => {
  * Picks a property from an object and returns the value of the property.
  *
  * @param obj - The object from which the property should be read.
+ * @param path - The path at which the property should be read.
  *
  * @returns The value of the property.
  */
@@ -372,43 +373,42 @@ export const getProperty = (obj: NestedObject, path: string) => {
   return path.split('.').reduce((acc, key) => acc?.[key] as NestedObject, obj);
 };
 
-export const toInt = <T extends number | null = number>(
-  value: string,
-  defaultValue?: T,
-): number | T => {
-  const def = defaultValue === undefined ? 0 : defaultValue;
-  if (value === null || value === undefined) return def;
-
-  const result = Number.parseInt(value);
-  return Number.isNaN(result) ? def : result;
-};
-
-export const setProperty = <T extends NestedObject, K>(
-  initial: T,
+/**
+ * Sets a property on an object and returns the object with the property set.
+ *
+ * @param obj - The object on which the property should be set.
+ * @param path - The path at which the property should be set.
+ * @param value - The value of the property.
+ *
+ * @returns The object with the property set.
+ */
+export const setProperty = <T extends NestedObject>(
+  obj: T,
   path: string,
-  value: K,
+  value: unknown,
 ): T => {
-  if (!initial) return setProperty({} as T, path, value);
-  if (!path || value === undefined) return initial;
+  if (!obj) return setProperty({} as T, path, value);
+  if (!path || value === undefined) return obj;
 
   const segments = path.split(/[.[\]]/g).filter((x) => !!x.trim());
 
   const _set = (node: NestedObject) => {
     if (segments.length > 1) {
       const key = segments.shift() as string;
-      const nextIsNum = toInt(segments[0], null) !== null;
+      const nextIsNum = !Number.isNaN(Number.parseInt(segments[0]));
 
-      // If the current property is not an object or array, overwrite it
+      // If the current property is not an object or array, overwrite it.
       if (typeof node[key] !== 'object' || node[key] === null) {
         node[key] = nextIsNum ? [] : {};
       }
+
       _set(node[key] as NestedObject);
     } else {
       node[segments[0]] = value;
     }
   };
 
-  const cloned = structuredClone(initial);
+  const cloned = structuredClone(obj);
   _set(cloned);
   return cloned;
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -388,7 +388,6 @@ export const setProperty = <T extends NestedObject>(
   value: unknown,
 ): T => {
   if (!obj) return setProperty({} as T, path, value);
-  if (!path || value === undefined) return obj;
 
   const segments = path.split(/[.[\]]/g).filter((x) => !!x.trim());
 

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -296,9 +296,30 @@ test('get single record including unrelated records with filter', async () => {
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       updatedBy: null,
     },
-    account: {
-      firstName: expect.any(String),
-    },
+    members: [
+      {
+        account: expect.stringMatching(RECORD_ID_REGEX),
+        id: expect.stringMatching(RECORD_ID_REGEX),
+        ronin: {
+          locked: false,
+          createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          createdBy: null,
+          updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          updatedBy: null,
+        },
+      },
+      {
+        account: expect.stringMatching(RECORD_ID_REGEX),
+        id: expect.stringMatching(RECORD_ID_REGEX),
+        ronin: {
+          locked: false,
+          createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          createdBy: null,
+          updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          updatedBy: null,
+        },
+      },
+    ],
   });
 });
 

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -56,7 +56,7 @@ test('get single record including unrelated record without filter', async () => 
   expect(result.record).toEqual({
     id: expect.stringMatching(RECORD_ID_REGEX),
     ronin: {
-      locked: null,
+      locked: false,
       createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       createdBy: null,
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -65,7 +65,7 @@ test('get single record including unrelated record without filter', async () => 
     team: {
       id: expect.stringMatching(RECORD_ID_REGEX),
       ronin: {
-        locked: null,
+        locked: false,
         createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         createdBy: null,
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -134,7 +134,7 @@ test('get single record including unrelated record with filter', async () => {
   expect(result.record).toEqual({
     id: expect.stringMatching(RECORD_ID_REGEX),
     ronin: {
-      locked: null,
+      locked: false,
       createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       createdBy: null,
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -143,7 +143,7 @@ test('get single record including unrelated record with filter', async () => {
     account: {
       id: expect.stringMatching(RECORD_ID_REGEX),
       ronin: {
-        locked: null,
+        locked: false,
         createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         createdBy: null,
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -219,7 +219,7 @@ test('get single record including unrelated record with filter and specific fiel
   expect(result.record).toEqual({
     id: expect.stringMatching(RECORD_ID_REGEX),
     ronin: {
-      locked: null,
+      locked: false,
       createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       createdBy: null,
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -116,7 +116,7 @@ test('expand column names', async () => {
   expect(result.record).toEqual({
     id: expect.stringMatching(RECORD_ID_REGEX),
     ronin: {
-      locked: null,
+      locked: false,
       createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       createdBy: null,
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
@@ -125,7 +125,7 @@ test('expand column names', async () => {
     account: {
       id: expect.stringMatching(RECORD_ID_REGEX),
       ronin: {
-        locked: null,
+        locked: false,
         createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         createdBy: null,
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -113,7 +113,7 @@ test('expand column names', async () => {
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
 
-  expect(result.record).toMatchObject({
+  expect(result.record).toEqual({
     id: expect.stringMatching(RECORD_ID_REGEX),
     ronin: {
       locked: null,


### PR DESCRIPTION
This change covers 4 more test cases for output formatting, which means only 24 are remaining.

Specifically, the tests assert the scenarios in which multiple records are being joined into one record.