### PR TITLE
Added remaining output tests for joins

### DIFF
--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -105,10 +105,6 @@ export const handleIncluding = (
     model.tableAlias = model.tableAlias || model.table;
 
     if (joinType === 'LEFT') {
-      if (!single) {
-        tableSubQuery = `SELECT * FROM "${model.table}" LIMIT 1`;
-      }
-
       const subStatement = composeConditions(
         models,
         { ...relatedModel, tableAlias },
@@ -122,6 +118,11 @@ export const handleIncluding = (
 
       statement += ` ON (${subStatement})`;
     }
+
+    // If multiple records are being joined, we need to prepare a sub query that can be
+    // used as a replacement for the root table, since we want to guarantee that the root
+    // statement only returns one row, and multiple rows are being joined to it.
+    if (!single) tableSubQuery = `SELECT * FROM "${model.table}" LIMIT 1`;
   }
 
   return { statement, tableSubQuery };

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -2,6 +2,8 @@ import type { Model, ModelField } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
 import {
   QUERY_SYMBOLS,
+  RAW_FIELD_TYPES,
+  type RawFieldType,
   composeIncludedTableAlias,
   flatten,
   getSymbol,
@@ -111,6 +113,13 @@ export const handleSelecting = (
       }
 
       instructions.including![key] = newValue;
+
+      loadedFields.push({
+        slug: key,
+        type: RAW_FIELD_TYPES.includes(typeof value as RawFieldType)
+          ? (typeof value as RawFieldType)
+          : 'string',
+      });
     }
   }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,6 +42,10 @@ export const RONIN_MODEL_FIELD_REGEX = new RegExp(
   'g',
 );
 
+// JavaScript types that can directly be used as field types in RONIN.
+export const RAW_FIELD_TYPES = ['string', 'number', 'boolean'] as const;
+export type RawFieldType = (typeof RAW_FIELD_TYPES)[number];
+
 /**
  * Composes an alias for a table that should be joined into the root table.
  *

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -595,13 +595,13 @@ test('get single record including unrelated ordered records', async () => {
   });
 });
 
-test('get single record including ephemeral field', () => {
+test('get single record including ephemeral field', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        space: {
+        team: {
           including: {
-            name: 'Example Space',
+            companyName: 'Example Company',
           },
         },
       },
@@ -610,7 +610,7 @@ test('get single record including ephemeral field', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'team',
     },
   ];
 
@@ -618,11 +618,26 @@ test('get single record including ephemeral field', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ?1 as "name" FROM "spaces" LIMIT 1`,
-      params: ['Example Space'],
+      statement: `SELECT *, ?1 as "companyName" FROM "teams" LIMIT 1`,
+      params: ['Example Company'],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    companyName: 'Example Company',
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+  });
 });
 
 test('get single record including ephemeral field containing expression', () => {

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -705,14 +705,14 @@ test('get single record including ephemeral field containing expression', async 
   });
 });
 
-test('get single record including deeply nested ephemeral field', () => {
+test('get single record including deeply nested ephemeral field', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        space: {
+        beach: {
           including: {
-            invoice: {
-              recipient: 'receipts@site.co',
+            sand: {
+              quality: 'extraordinary',
             },
           },
         },
@@ -722,7 +722,7 @@ test('get single record including deeply nested ephemeral field', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'beach',
     },
   ];
 
@@ -730,9 +730,26 @@ test('get single record including deeply nested ephemeral field', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ?1 as "invoice.recipient" FROM "spaces" LIMIT 1`,
-      params: ['receipts@site.co'],
+      statement: `SELECT *, ?1 as "sand.quality" FROM "beaches" LIMIT 1`,
+      params: ['extraordinary'],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    sand: {
+      quality: 'extraordinary',
+    },
+  });
 });


### PR DESCRIPTION
This change adds output assertions for all remaining tests in `tests/instructions/including.test.ts`, which is the test file used to assert queries that contain joins.