### PR TITLE
Assert remaining default query presets (like default joins)

### DIFF
--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -14,8 +14,8 @@ export type NativeRecord = Record<string, unknown> & {
   };
 };
 
-export type SingleRecordResult = {
-  record: NativeRecord | null;
+export type SingleRecordResult<T = NativeRecord> = {
+  record: T | null;
 };
 
 export type MultipleRecordResult = {

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -17,31 +17,40 @@
     {
       "id": "pro_39h8fhe98hefah8j",
       "name": "Apple",
-      "position": 1
+      "position": 1,
+      "team": "tea_39h8fhe98hefah8j"
     },
     {
       "id": "pro_39h8fhe98hefah9j",
       "name": "Banana",
-      "position": 2
+      "position": 2,
+      "team": "tea_39h8fhe98hefah8j"
     },
     {
       "id": "pro_39h8fhe98hefah0j",
       "name": "Cherry",
-      "position": 3
+      "position": 3,
+      "team": "tea_39h8fhe98hefah9j"
     }
   ],
   "member": [
     {
       "id": "mem_39h8fhe98hefah8j",
-      "account": "acc_39h8fhe98hefah8j"
+      "account": "acc_39h8fhe98hefah8j",
+      "team": "tea_39h8fhe98hefah8j",
+      "activeAt": "2024-12-11T10:47:58.079Z"
     },
     {
       "id": "mem_39h8fhe98hefah9j",
-      "account": "acc_39h8fhe98hefah9j"
+      "account": "acc_39h8fhe98hefah9j",
+      "team": "tea_39h8fhe98hefah8j",
+      "activeAt": "2024-11-11T10:47:58.079Z"
     },
     {
       "id": "mem_39h8fhe98hefah0j",
-      "account": "acc_39h8fhe98hefah8j"
+      "account": "acc_39h8fhe98hefah8j",
+      "team": "tea_39h8fhe98hefah9j",
+      "activeAt": "2024-10-11T10:47:58.079Z"
     }
   ],
   "team": [

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -282,7 +282,7 @@ test('get single record for preset containing field without condition', async ()
   });
 });
 
-test('get single record for preset on existing object instruction', () => {
+test('get single record for preset on existing object instruction', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -290,7 +290,7 @@ test('get single record for preset on existing object instruction', () => {
           with: {
             account: 'acc_39h8fhe98hefah8j',
           },
-          for: ['specificSpace'],
+          for: ['specificTeam'],
         },
       },
     },
@@ -298,7 +298,7 @@ test('get single record for preset on existing object instruction', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'team',
     },
     {
       slug: 'account',
@@ -312,19 +312,19 @@ test('get single record for preset on existing object instruction', () => {
           target: 'account',
         },
         {
-          slug: 'space',
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
       ],
       presets: [
         {
           instructions: {
             with: {
-              space: 'spa_m9h8oha94helaji',
+              team: 'tea_39h8fhe98hefah9j',
             },
           },
-          slug: 'specificSpace',
+          slug: 'specificTeam',
         },
       ],
     },
@@ -334,12 +334,27 @@ test('get single record for preset on existing object instruction', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'SELECT * FROM "members" WHERE ("space" = ?1 AND "account" = ?2) LIMIT 1',
-      params: ['spa_m9h8oha94helaji', 'acc_39h8fhe98hefah8j'],
+      statement: 'SELECT * FROM "members" WHERE ("team" = ?1 AND "account" = ?2) LIMIT 1',
+      params: ['tea_39h8fhe98hefah9j', 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: 'mem_39h8fhe98hefah0j',
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    account: 'acc_39h8fhe98hefah8j',
+    team: 'tea_39h8fhe98hefah9j',
+  });
 });
 
 test('get single record for preset on existing array instruction', () => {

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -74,11 +74,11 @@ test('get single record for preset', async () => {
   });
 });
 
-test('get single record for preset containing field with condition', () => {
+test('get single record for preset containing field with condition', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        view: {
+        product: {
           for: {
             activeMember: 'acc_39h8fhe98hefah8j',
           },
@@ -89,7 +89,7 @@ test('get single record for preset containing field with condition', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'team',
     },
     {
       slug: 'account',
@@ -103,9 +103,9 @@ test('get single record for preset containing field with condition', () => {
           target: 'account',
         },
         {
-          slug: 'space',
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
         {
           slug: 'activeAt',
@@ -114,26 +114,30 @@ test('get single record for preset containing field with condition', () => {
       ],
     },
     {
-      slug: 'view',
+      slug: 'product',
       fields: [
         {
-          slug: 'space',
+          slug: 'name',
+          type: 'string',
+        },
+        {
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
       ],
       presets: [
         {
           instructions: {
             with: {
-              space: {
-                notBeing: {
+              team: {
+                being: {
                   [QUERY_SYMBOLS.QUERY]: {
                     get: {
                       member: {
                         with: { account: QUERY_SYMBOLS.VALUE },
                         orderedBy: { descending: ['activeAt'] },
-                        selecting: ['space'],
+                        selecting: ['team'],
                       },
                     },
                   },
@@ -152,18 +156,34 @@ test('get single record for preset containing field with condition', () => {
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "views" WHERE ("space" != (SELECT "space" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
+        'SELECT * FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
       params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: 'pro_39h8fhe98hefah8j',
+    name: 'Apple',
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    team: 'tea_39h8fhe98hefah8j',
+  });
 });
 
-test('get single record for preset containing field without condition', () => {
+test('get single record for preset containing field without condition', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        view: {
+        product: {
           for: {
             activeMember: 'acc_39h8fhe98hefah8j',
           },
@@ -174,7 +194,7 @@ test('get single record for preset containing field without condition', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'team',
     },
     {
       slug: 'account',
@@ -188,9 +208,9 @@ test('get single record for preset containing field without condition', () => {
           target: 'account',
         },
         {
-          slug: 'space',
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
         {
           slug: 'activeAt',
@@ -199,25 +219,29 @@ test('get single record for preset containing field without condition', () => {
       ],
     },
     {
-      slug: 'view',
+      slug: 'product',
       fields: [
         {
-          slug: 'space',
+          slug: 'name',
+          type: 'string',
+        },
+        {
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
       ],
       presets: [
         {
           instructions: {
             with: {
-              space: {
+              team: {
                 [QUERY_SYMBOLS.QUERY]: {
                   get: {
                     member: {
                       with: { account: QUERY_SYMBOLS.VALUE },
                       orderedBy: { descending: ['activeAt'] },
-                      selecting: ['space'],
+                      selecting: ['team'],
                     },
                   },
                 },
@@ -235,11 +259,27 @@ test('get single record for preset containing field without condition', () => {
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "views" WHERE ("space" = (SELECT "space" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
+        'SELECT * FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
       params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: 'pro_39h8fhe98hefah8j',
+    name: 'Apple',
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    team: 'tea_39h8fhe98hefah8j',
+  });
 });
 
 test('get single record for preset on existing object instruction', () => {

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -357,13 +357,13 @@ test('get single record for preset on existing object instruction', async () => 
   });
 });
 
-test('get single record for preset on existing array instruction', () => {
+test('get single record for preset on existing array instruction', async () => {
   const queries: Array<Query> = [
     {
       get: {
         member: {
           selecting: ['account'],
-          for: ['selectedSpace'],
+          for: ['selectedTeam'],
         },
       },
     },
@@ -371,7 +371,7 @@ test('get single record for preset on existing array instruction', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'space',
+      slug: 'team',
     },
     {
       slug: 'account',
@@ -385,17 +385,17 @@ test('get single record for preset on existing array instruction', () => {
           target: 'account',
         },
         {
-          slug: 'space',
+          slug: 'team',
           type: 'link',
-          target: 'space',
+          target: 'team',
         },
       ],
       presets: [
         {
           instructions: {
-            selecting: ['space'],
+            selecting: ['team'],
           },
-          slug: 'selectedSpace',
+          slug: 'selectedTeam',
         },
       ],
     },
@@ -405,11 +405,22 @@ test('get single record for preset on existing array instruction', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "space", "account" FROM "members" LIMIT 1',
+      statement: 'SELECT "team", "account" FROM "members" LIMIT 1',
       params: [],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(
+    rawResults,
+    false,
+  )[0] as unknown as SingleRecordResult<{ account: string; team: string }>;
+
+  expect(result.record).toEqual({
+    account: 'acc_39h8fhe98hefah8j',
+    team: 'tea_39h8fhe98hefah8j',
+  });
 });
 
 test('get single record including parent record (many-to-one)', async () => {


### PR DESCRIPTION
This change adds output assertions for all remaining tests in the `tests/instructions/for.test.ts` file (as mentioned before, the name of the actual instruction is not final — in prod it is currently called `including`).