### PR TITLE
Assert pagination (limited amount of records)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,28 +234,40 @@ class Transaction {
       // If the amount of records was limited to a specific amount, that means pagination
       // should be activated. This is only possible if the query matched any records.
       if (pageSize && output.records.length > 0) {
-        // Pagination cursor for the previous page. Only available if an existing
-        // cursor was provided in the query instructions.
-        if (queryInstructions?.before || queryInstructions?.after) {
-          const direction = queryInstructions?.before ? 'moreAfter' : 'moreBefore';
-          const firstRecord = output.records[0] as NativeRecord;
-
-          output[direction] = generatePaginationCursor(
-            model,
-            queryInstructions.orderedBy,
-            firstRecord,
-          );
-        }
-
         // Pagination cursor for the next page.
         if (output.records.length > pageSize) {
+          // Remove one record from the list, because we always load one too much, in
+          // order to see if there are more records available.
+          if (queryInstructions?.before) {
+            output.records.shift();
+          } else {
+            output.records.pop();
+          }
+
           const direction = queryInstructions?.before ? 'moreBefore' : 'moreAfter';
-          const lastRecord = output.records.pop() as NativeRecord;
+          const lastRecord = output.records.at(
+            direction === 'moreAfter' ? -1 : 0,
+          ) as NativeRecord;
 
           output[direction] = generatePaginationCursor(
             model,
             queryInstructions.orderedBy,
             lastRecord,
+          );
+        }
+
+        // Pagination cursor for the previous page. Only available if an existing
+        // cursor was provided in the query instructions.
+        if (queryInstructions?.before || queryInstructions?.after) {
+          const direction = queryInstructions?.before ? 'moreAfter' : 'moreBefore';
+          const firstRecord = output.records.at(
+            direction === 'moreAfter' ? -1 : 0,
+          ) as NativeRecord;
+
+          output[direction] = generatePaginationCursor(
+            model,
+            queryInstructions.orderedBy,
+            firstRecord,
           );
         }
       }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -7,9 +7,9 @@ export type NativeRecord = Record<string, unknown> & {
   id: string;
   ronin: {
     locked: boolean;
-    createdAt: Date;
+    createdAt: string;
     createdBy: string | null;
-    updatedAt: Date;
+    updatedAt: string;
     updatedBy: string | null;
   };
 };

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -59,32 +59,48 @@
       "locations": {
         "europe": "berlin"
       },
-      "billing.currency": "EUR"
+      "billing": {
+        "currency": "EUR"
+      }
     },
     {
       "id": "tea_39h8fhe98hefah9j",
       "locations": {
         "europe": "london"
       },
-      "billing.currency": "GBP"
+      "billing": {
+        "currency": "GBP"
+      }
     }
   ],
   "beach": [
     {
       "id": "bea_39h8fhe98hefah8j",
-      "name": "Bondi"
+      "name": "Bondi",
+      "ronin": {
+        "createdAt": "2024-12-11T10:47:58.079Z"
+      }
     },
     {
       "id": "bea_39h8fhe98hefah9j",
-      "name": "Manly"
+      "name": "Manly",
+      "ronin": {
+        "createdAt": "2024-12-10T10:47:58.079Z"
+      }
     },
     {
       "id": "bea_39h8fhe98hefah0j",
-      "name": "Coogee"
+      "name": "Coogee",
+      "ronin": {
+        "createdAt": "2024-12-09T10:47:58.079Z"
+      }
     },
     {
       "id": "bea_39h8fhe98hefah1j",
-      "name": "Cronulla"
+      "name": "Cronulla",
+      "ronin": {
+        "createdAt": "2024-12-08T10:47:58.079Z"
+      }
     }
   ],
   "category": [

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -38,19 +38,31 @@
       "id": "mem_39h8fhe98hefah8j",
       "account": "acc_39h8fhe98hefah8j",
       "team": "tea_39h8fhe98hefah8j",
-      "activeAt": "2024-12-11T10:47:58.079Z"
+      "activeAt": "2024-12-11T10:47:58.079Z",
+      "pending": true,
+      "ronin": {
+        "createdAt": "2024-12-11T10:47:58.079Z"
+      }
     },
     {
       "id": "mem_39h8fhe98hefah9j",
       "account": "acc_39h8fhe98hefah9j",
       "team": "tea_39h8fhe98hefah8j",
-      "activeAt": "2024-11-11T10:47:58.079Z"
+      "activeAt": "2024-11-10T10:47:58.079Z",
+      "pending": false,
+      "ronin": {
+        "createdAt": "2024-11-10T10:47:58.079Z"
+      }
     },
     {
       "id": "mem_39h8fhe98hefah0j",
       "account": "acc_39h8fhe98hefah8j",
       "team": "tea_39h8fhe98hefah9j",
-      "activeAt": "2024-10-11T10:47:58.079Z"
+      "activeAt": "2024-10-09T10:47:58.079Z",
+      "pending": true,
+      "ronin": {
+        "createdAt": "2024-10-09T10:47:58.079Z"
+      }
     }
   ],
   "team": [

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -18,19 +18,37 @@
       "id": "pro_39h8fhe98hefah8j",
       "name": "Apple",
       "position": 1,
-      "team": "tea_39h8fhe98hefah8j"
+      "team": "tea_39h8fhe98hefah8j",
+      "ronin": {
+        "createdAt": "2024-12-11T10:47:58.079Z"
+      }
     },
     {
       "id": "pro_39h8fhe98hefah9j",
       "name": "Banana",
       "position": 2,
-      "team": "tea_39h8fhe98hefah8j"
+      "team": "tea_39h8fhe98hefah8j",
+      "ronin": {
+        "createdAt": "2024-12-10T10:47:58.079Z"
+      }
     },
     {
       "id": "pro_39h8fhe98hefah0j",
       "name": "Cherry",
       "position": 3,
-      "team": "tea_39h8fhe98hefah9j"
+      "team": "tea_39h8fhe98hefah9j",
+      "ronin": {
+        "createdAt": "2024-12-09T10:47:58.079Z"
+      }
+    },
+    {
+      "id": "pro_39h8fhe98hefah1j",
+      "name": "Peach",
+      "position": 4,
+      "team": "tea_39h8fhe98hefah9j",
+      "ronin": {
+        "createdAt": "2024-12-08T10:47:58.079Z"
+      }
     }
   ],
   "member": [

--- a/tests/fixtures/data.json
+++ b/tests/fixtures/data.json
@@ -81,6 +81,10 @@
     {
       "id": "bea_39h8fhe98hefah0j",
       "name": "Coogee"
+    },
+    {
+      "id": "bea_39h8fhe98hefah1j",
+      "name": "Cronulla"
     }
   ],
   "category": [

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,6 +1,6 @@
 import fixtureData from '@/fixtures/data.json';
 import { type Model, type Query, ROOT_MODEL, Transaction } from '@/src/index';
-import { convertToSnakeCase } from '@/src/utils/helpers';
+import { convertToSnakeCase, getProperty, setProperty } from '@/src/utils/helpers';
 import { Engine } from '@ronin/engine';
 import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
@@ -48,12 +48,12 @@ const prefillDatabase = async (databaseName: string, models: Array<Model>) => {
       const data = fixtureData[fixtureSlug] || [];
 
       const formattedData = data.map((row) => {
-        const newRow: Record<string, unknown> = {};
+        let newRow: Record<string, unknown> = {};
 
         for (const field of createdModel.fields || []) {
-          const match = (row as Record<string, unknown>)[field.slug];
+          const match = getProperty(row, field.slug);
           if (typeof match === 'undefined') continue;
-          newRow[field.slug] = match;
+          newRow = setProperty(newRow, field.slug, match);
         }
 
         return newRow;

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -1,15 +1,17 @@
 import { expect, test } from 'bun:test';
+import { RECORD_TIMESTAMP_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
+import type { MultipleRecordResult } from '@/src/types/result';
 import { RoninError } from '@/src/utils/helpers';
 import { CURSOR_NULL_PLACEHOLDER } from '@/src/utils/pagination';
 
-test('get multiple records before cursor', () => {
+test('get multiple records before cursor', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        accounts: {
-          before: '1667575193779',
-          limitedTo: 100,
+        beaches: {
+          before: '1733654878079',
+          limitedTo: 2,
         },
       },
     },
@@ -17,7 +19,13 @@ test('get multiple records before cursor', () => {
 
   const models: Array<Model> = [
     {
-      slug: 'account',
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
     },
   ];
 
@@ -25,11 +33,42 @@ test('get multiple records before cursor', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE (("ronin.createdAt" > '2022-11-04T15:19:53.779Z')) ORDER BY "ronin.createdAt" DESC LIMIT 101`,
+      statement: `SELECT * FROM "beaches" WHERE (("ronin.createdAt" > '2024-12-08T10:47:58.079Z')) ORDER BY "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
+
+  expect(result.records).toEqual([
+    {
+      id: 'bea_39h8fhe98hefah9j',
+      ronin: {
+        locked: false,
+        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        createdBy: null,
+        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        updatedBy: null,
+      },
+      name: 'Manly',
+    },
+    {
+      id: 'bea_39h8fhe98hefah0j',
+      ronin: {
+        locked: false,
+        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        createdBy: null,
+        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        updatedBy: null,
+      },
+      name: 'Coogee',
+    },
+  ]);
+
+  expect(result.moreBefore).toBe('1733827678079');
+  expect(result.moreAfter).toBe('1733741278079');
 });
 
 test('get multiple records before cursor ordered by string field', () => {

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -42,12 +42,15 @@ test('get multiple records before cursor', async () => {
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
+  const firstRecordTime = new Date('2024-12-10T10:47:58.079Z');
+  const lastRecordTime = new Date('2024-12-09T10:47:58.079Z');
+
   expect(result.records).toEqual([
     {
       id: 'bea_39h8fhe98hefah9j',
       ronin: {
         locked: false,
-        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        createdAt: firstRecordTime.toISOString(),
         createdBy: null,
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         updatedBy: null,
@@ -58,7 +61,7 @@ test('get multiple records before cursor', async () => {
       id: 'bea_39h8fhe98hefah0j',
       ronin: {
         locked: false,
-        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        createdAt: lastRecordTime.toISOString(),
         createdBy: null,
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         updatedBy: null,
@@ -67,8 +70,8 @@ test('get multiple records before cursor', async () => {
     },
   ]);
 
-  expect(result.moreBefore).toBe('1733827678079');
-  expect(result.moreAfter).toBe('1733741278079');
+  expect(result.moreBefore).toBe(firstRecordTime.getTime().toString());
+  expect(result.moreAfter).toBe(lastRecordTime.getTime().toString());
 });
 
 test('get multiple records before cursor ordered by string field', () => {

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -325,11 +325,11 @@ test('get multiple records before cursor ordered by empty string field', async (
       slug: 'beach',
       fields: [
         {
-          slug: 'sandColor',
+          slug: 'name',
           type: 'string',
         },
         {
-          slug: 'name',
+          slug: 'sandColor',
           type: 'string',
         },
       ],
@@ -385,16 +385,16 @@ test('get multiple records before cursor ordered by empty string field', async (
   expect(result.moreAfter).toBe(`${CURSOR_NULL_PLACEHOLDER},${lastRecordTime.getTime()}`);
 });
 
-test('get multiple records before cursor ordered by empty boolean field', () => {
+test('get multiple records before cursor ordered by empty boolean field', async () => {
   const queries: Array<Query> = [
     {
       get: {
-        accounts: {
-          before: `${CURSOR_NULL_PLACEHOLDER},1667575193779`,
+        beaches: {
+          before: `${CURSOR_NULL_PLACEHOLDER},1733654878079`,
           orderedBy: {
-            descending: ['active'],
+            descending: ['rating'],
           },
-          limitedTo: 100,
+          limitedTo: 2,
         },
       },
     },
@@ -402,11 +402,15 @@ test('get multiple records before cursor ordered by empty boolean field', () => 
 
   const models: Array<Model> = [
     {
-      slug: 'account',
+      slug: 'beach',
       fields: [
         {
-          slug: 'active',
-          type: 'boolean',
+          slug: 'name',
+          type: 'string',
+        },
+        {
+          slug: 'rating',
+          type: 'number',
         },
       ],
     },
@@ -416,11 +420,49 @@ test('get multiple records before cursor ordered by empty boolean field', () => 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE (("active" IS NOT NULL) OR ("active" IS NULL AND ("ronin.createdAt" > '2022-11-04T15:19:53.779Z'))) ORDER BY "active" DESC, "ronin.createdAt" DESC LIMIT 101`,
+      statement: `SELECT * FROM "beaches" WHERE (("rating" IS NOT NULL) OR ("rating" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "rating" DESC, "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
   ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
+
+  const firstRecordTime = new Date('2024-12-10T10:47:58.079Z');
+  const lastRecordTime = new Date('2024-12-09T10:47:58.079Z');
+
+  expect(result.records).toEqual([
+    {
+      id: 'bea_39h8fhe98hefah9j',
+      ronin: {
+        locked: false,
+        createdAt: firstRecordTime.toISOString(),
+        createdBy: null,
+        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        updatedBy: null,
+      },
+      name: 'Manly',
+      rating: null,
+    },
+    {
+      id: 'bea_39h8fhe98hefah0j',
+      ronin: {
+        locked: false,
+        createdAt: lastRecordTime.toISOString(),
+        createdBy: null,
+        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        updatedBy: null,
+      },
+      name: 'Coogee',
+      rating: null,
+    },
+  ]);
+
+  expect(result.moreBefore).toBe(
+    `${CURSOR_NULL_PLACEHOLDER},${firstRecordTime.getTime()}`,
+  );
+  expect(result.moreAfter).toBe(`${CURSOR_NULL_PLACEHOLDER},${lastRecordTime.getTime()}`);
 });
 
 test('get multiple records before cursor ordered by empty number field', () => {

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -389,7 +389,7 @@ test('get single record including unrelated records without filter', async () =>
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       updatedBy: null,
     },
-    beaches: new Array(3).fill({
+    beaches: new Array(4).fill({
       id: expect.stringMatching(RECORD_ID_REGEX),
       name: expect.any(String),
       ronin: {
@@ -583,6 +583,17 @@ test('get single record including unrelated ordered records', async () => {
       {
         id: 'bea_39h8fhe98hefah0j',
         name: 'Coogee',
+        ronin: {
+          locked: false,
+          createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          createdBy: null,
+          updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          updatedBy: null,
+        },
+      },
+      {
+        id: 'bea_39h8fhe98hefah1j',
+        name: 'Cronulla',
         ronin: {
           locked: false,
           createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),


### PR DESCRIPTION
This change ensures that the test suite asserts all possible outputs (and therefore also pagination cursors) related to records getting paginated, meaning cases in which a `limitedTo` instruction is provided for a query.