### PR TITLE
Let models reference themselves

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -621,7 +621,8 @@ const getFieldStatement = (
 
     // Passing the current model here is imporant, because it allows for creating a model
     // that references itself.
-    const targetTable = getModelBySlug([...models, model], field.target).table;
+    const modelList = models.some(item => item.slug === model.slug) ? models : [...models, model];
+    const targetTable = getModelBySlug(modelList, field.target).table;
 
     statement += ` REFERENCES ${targetTable}("id")`;
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -618,7 +618,10 @@ const getFieldStatement = (
     if (field.kind === 'many') return null;
 
     const actions = field.actions || {};
-    const targetTable = getModelBySlug(models, field.target).table;
+
+    // Passing the current model here is imporant, because it allows for creating a model
+    // that references itself.
+    const targetTable = getModelBySlug([...models, model], field.target).table;
 
     statement += ` REFERENCES ${targetTable}("id")`;
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -621,7 +621,9 @@ const getFieldStatement = (
 
     // Passing the current model here is imporant, because it allows for creating a model
     // that references itself.
-    const modelList = models.some(item => item.slug === model.slug) ? models : [...models, model];
+    const modelList = models.some((item) => item.slug === model.slug)
+      ? models
+      : [...models, model];
     const targetTable = getModelBySlug(modelList, field.target).table;
 
     statement += ` REFERENCES ${targetTable}("id")`;

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -87,7 +87,7 @@ const NON_RAW_ENGINE = new Engine({
  * @param raw - By default, the results are returned in a raw format, meaning in the same
  * format in which SQLite returns them (rows being arrays of values). If `raw` is set to
  * `false`, the rows are returned as objects, which simulates the behavior of drivers that
- * are incompatible of returning raw results.
+ * are incapable of returning raw results.
  *
  * @returns A list of rows resulting from the executed statements.
  */

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -154,6 +154,34 @@ test('create new model that has system models associated with it', () => {
   });
 });
 
+test('create new model that references itself', () => {
+  const fields = [
+    {
+      slug: 'parentTeam',
+      type: 'link',
+      target: 'team',
+    },
+  ];
+
+  const queries: Array<Query> = [
+    {
+      create: {
+        model: { slug: 'team', fields },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements[0]).toEqual({
+    statement:
+      'CREATE TABLE "teams" ("id" TEXT PRIMARY KEY, "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME, "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME, "ronin.updatedBy" TEXT, "parentTeam" TEXT REFERENCES teams("id"))',
+    params: [],
+  });
+});
+
 // Ensure that, if the `slug` of a model changes during an update, an `ALTER TABLE`
 // statement is generated for it.
 test('alter existing model (slug)', () => {


### PR DESCRIPTION
This change makes it possible to create a model that contains a field of type "link" whose target is the model itself.