### PR TITLE
Added model field types to results

### DIFF
--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -22,8 +22,8 @@ export type SingleRecordResult<T = NativeRecord> = {
   modelFields: Record<ModelField['slug'], ModelField['type']>;
 };
 
-export type MultipleRecordResult = {
-  records: Array<NativeRecord>;
+export type MultipleRecordResult<T = NativeRecord> = {
+  records: Array<T>;
   moreAfter?: string;
   moreBefore?: string;
 
@@ -34,4 +34,7 @@ export type AmountResult = {
   amount: number;
 };
 
-export type Result = SingleRecordResult | MultipleRecordResult | AmountResult;
+export type Result<T = NativeRecord> =
+  | SingleRecordResult<T>
+  | MultipleRecordResult<T>
+  | AmountResult;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,3 +1,5 @@
+import type { ModelField } from '@/src/types/model';
+
 export type RawRow = Array<unknown>;
 export type ObjectRow = Record<string, unknown>;
 
@@ -16,12 +18,16 @@ export type NativeRecord = Record<string, unknown> & {
 
 export type SingleRecordResult<T = NativeRecord> = {
   record: T | null;
+
+  modelFields: Record<ModelField['slug'], ModelField['type']>;
 };
 
 export type MultipleRecordResult = {
   records: Array<NativeRecord>;
   moreAfter?: string;
   moreBefore?: string;
+
+  modelFields: Record<ModelField['slug'], ModelField['type']>;
 };
 
 export type AmountResult = {


### PR DESCRIPTION
The TypeScript client package currently requires the types of all fields to be listed in the compiler result, since the client needs to format certain fields (such as fields of type "date") whose type cannot be serialized/represented in the format in which the compiler output is sent to the client (JSON).