### PR TITLE
Ensure correct order of results

### DIFF
--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,3 +1,4 @@
+import type { ModelField } from '@/src/types/model';
 import type {
   AddInstructionsSchema,
   AddQuerySchema,
@@ -86,4 +87,9 @@ export interface Statement {
   statement: string;
   params: Array<unknown>;
   returning?: boolean;
+}
+
+export interface InternalStatement extends Statement {
+  query: Query;
+  fields: Array<ModelField>;
 }

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,7 +1,16 @@
 import { expect, test } from 'bun:test';
-import { RECORD_ID_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
+import {
+  RECORD_ID_REGEX,
+  RECORD_TIMESTAMP_REGEX,
+  queryEphemeralDatabase,
+} from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
-import type { AmountResult, SingleRecordResult } from '@/src/types/result';
+import type {
+  AmountResult,
+  NativeRecord,
+  Result,
+  SingleRecordResult,
+} from '@/src/types/result';
 
 test('get single record', async () => {
   const queries: Array<Query> = [
@@ -104,4 +113,99 @@ test('count multiple records', async () => {
   const result = transaction.formatResults(rawResults)[0] as AmountResult;
 
   expect(result.amount).toBeNumber();
+});
+
+test('pass multiple record queries at once', async () => {
+  const queries: Array<Query> = [
+    {
+      count: {
+        accounts: null,
+      },
+    },
+    {
+      get: {
+        accounts: {
+          selecting: ['handle'],
+        },
+      },
+    },
+    {
+      get: {
+        account: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+      fields: [
+        {
+          slug: 'handle',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT COUNT(*) FROM "accounts"',
+      params: [],
+      returning: true,
+    },
+    {
+      statement: 'SELECT "handle" FROM "accounts"',
+      params: [],
+      returning: true,
+    },
+    {
+      statement: 'SELECT * FROM "accounts" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const results = transaction.formatResults(rawResults) as Array<
+    Result<Partial<NativeRecord>>
+  >;
+
+  // Assert whether the results are provided in the same order as the original queries.
+  expect(results).toEqual([
+    {
+      amount: 2,
+    },
+    {
+      records: [
+        {
+          handle: 'elaine',
+        },
+        {
+          handle: 'david',
+        },
+      ],
+      modelFields: expect.objectContaining({
+        id: 'string',
+      }),
+    },
+    {
+      record: {
+        id: expect.stringMatching(RECORD_ID_REGEX),
+        ronin: {
+          locked: false,
+          createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          createdBy: null,
+          updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+          updatedBy: null,
+        },
+        handle: 'elaine',
+      },
+      modelFields: expect.objectContaining({
+        id: 'string',
+      }),
+    },
+  ]);
 });


### PR DESCRIPTION
This changes guarantees that the order which results are provided by the compiler is the same order in which queries were provided to the compiler.