### PR TITLE
Accept generic argument when formatting results

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -386,12 +386,12 @@ export const getProperty = (obj: NestedObject, path: string) => {
  *
  * @returns The object with the property set.
  */
-export const setProperty = <T = NestedObject>(
-  obj: T,
+export const setProperty = <Object = NestedObject>(
+  obj: Object,
   path: string,
   value: unknown,
-): T => {
-  if (!obj) return setProperty({} as T, path, value);
+): Object => {
+  if (!obj) return setProperty({} as Object, path, value);
 
   const segments = path.split(/[.[\]]/g).filter((x) => !!x.trim());
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -386,7 +386,7 @@ export const getProperty = (obj: NestedObject, path: string) => {
  *
  * @returns The object with the property set.
  */
-export const setProperty = <T extends NestedObject>(
+export const setProperty = <T = NestedObject>(
   obj: T,
   path: string,
   value: unknown,


### PR DESCRIPTION
This change makes it possible to pass a generic argument when formatting the database results, like this:

```typescript
const results: = transaction.formatResults<Record>(rawResults);
```