### PR TITLE
Correctly format model entities

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -649,6 +649,8 @@ const PLURAL_MODEL_ENTITIES = {
   preset: 'presets',
 } as const;
 
+export const PLURAL_MODEL_ENTITIES_VALUES = Object.values(PLURAL_MODEL_ENTITIES);
+
 /**
  * Converts an array of model entites (such as fields) to an object where the keys are
  * the slugs of the entities and the values are their attributes.


### PR DESCRIPTION
This change ensures that any query that alters the database schema (`create.model`, `alter.model`, or `drop.model`) correctly returns an object that matches the `Model` type.