### PR TITLE
Handle missing model entities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,9 +176,11 @@ class Transaction {
           isMeta &&
           (PLURAL_MODEL_ENTITIES_VALUES as ReadonlyArray<string>).includes(newSlug)
         ) {
-          newValue = Object.entries(newValue as object).map(([slug, attributes]) => {
-            return { slug, ...attributes };
-          });
+          newValue = newValue
+            ? Object.entries(newValue as object).map(([slug, attributes]) => {
+                return { slug, ...attributes };
+              })
+            : [];
         }
 
         records[usableRowIndex] = setProperty<Record>(


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/compiler/pull/79 and ensures that the compiler doesn't crash if no model entities are defined for a given model that is being retrieved.