### PR TITLE
Wrap object with SQLite `json`

### DIFF
--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -47,7 +47,9 @@ export const prepareStatementValue = (
   // values must be plainly visible for manual human inspection.
   if (!statementParams) {
     const valueString =
-      typeof value === 'object' ? `json('${JSON.stringify(value)}')` : `'${value!.toString()}'`;
+      typeof value === 'object'
+        ? `json('${JSON.stringify(value)}')`
+        : `'${value!.toString()}'`;
 
     return valueString;
   }

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -47,8 +47,9 @@ export const prepareStatementValue = (
   // values must be plainly visible for manual human inspection.
   if (!statementParams) {
     const valueString =
-      typeof value === 'object' ? JSON.stringify(value) : value!.toString();
-    return `'${valueString}'`;
+      typeof value === 'object' ? `json('${JSON.stringify(value)}')` : `'${value!.toString()}'`;
+
+    return valueString;
   }
 
   let formattedValue = value;

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -44,7 +44,7 @@ test('inline statement parameters', async () => {
   });
 
   expect(transaction.statements[0].statement).toStartWith(
-    `INSERT INTO "accounts" ("handle", "emails", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ('elaine', '["test@site.co","elaine@site.com"]'`,
+    `INSERT INTO "accounts" ("handle", "emails", "id", "ronin.createdAt", "ronin.updatedAt") VALUES ('elaine', json('["test@site.co","elaine@site.com"]')`,
   );
   expect(transaction.statements[0].params).toEqual([]);
 


### PR DESCRIPTION
Wrap objects in SQLite [`json()`](https://www.sqlite.org/json1.html#jmini) to prevent escaping issues and ensure correct storage.