### PR TITLE
Report code coverage to Codecov

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   publish-experimental:
-    uses: ronin-co/github-actions/.github/workflows/publish-experimental.yml@main
-    with:
-      package_dir: './'  # Adjust if your package is in a subdirectory
+    uses: ronin-co/actions/.github/workflows/publish-experimental.yml@main
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_READ_AND_WRITE }}

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -16,10 +16,9 @@ on:
 
 jobs:
   publish:
-    uses: ronin-co/github-actions/.github/workflows/publish-manually.yml@main
+    uses: ronin-co/actions/.github/workflows/publish-manually.yml@main
     with:
       version_type: ${{ inputs.version_type }}
-      package_dir: './'  # Adjust if your package is in a subdirectory
     secrets:
       NPM_TOKEN_READ_AND_WRITE: ${{ secrets.NPM_TOKEN_READ_AND_WRITE }}
       ORG_GH_APP_ID: ${{ secrets.ORG_GH_RONIN_APP_ID }}

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -8,9 +8,8 @@ on:
 
 jobs:
   remove-experimental:
-    uses: ronin-co/github-actions/.github/workflows/remove-experimental.yml@main
+    uses: ronin-co/actions/.github/workflows/remove-experimental.yml@main
     with:
       branch_name: ${{ github.event.pull_request.head.ref }}
-      package_dir: './'  # Adjust if your package is in a subdirectory
     secrets:
       NPM_TOKEN_READ_AND_WRITE: ${{ secrets.NPM_TOKEN_READ_AND_WRITE }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,3 +13,5 @@ jobs:
     uses: ronin-co/actions/.github/workflows/validate.yml@main
     with:
       upload_coverage: true
+    secrets:
+      ORG_CODECOV_TOKEN: ${{ secrets.ORG_CODECOV_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   validate:
-    uses: ronin-co/github-actions/.github/workflows/validate.yml@main
+    uses: ronin-co/actions/.github/workflows/validate.yml@main
     with:
-      package_dir: './'  # Adjust if your package is in a subdirectory
+      upload_coverage: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # Build output
 dist
+
+# Code coverage report
+coverage

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Ronin GmbH
+   Copyright 2025 Ronin GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # RONIN Compiler
 
 [![Tests](https://github.com/ronin-co/compiler/actions/workflows/validate.yml/badge.svg)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
-[![Install Size](https://packagephobia.com/badge?p=@ronin/compiler)](https://packagephobia.com/result?p=@ronin/compiler)
+[![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler.svg?maxAge=2592000)](https://codecov.io/github/ronin-co/compiler?branch=main)
+[![install size](https://packagephobia.com/badge?p=@ronin/compiler)](https://packagephobia.com/result?p=@ronin/compiler)
 
 This package compiles [RONIN queries](https://ronin.co/docs/queries) to [SQLite](https://www.sqlite.org) statements.
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,7 @@
 [test]
 coverage = true
 coverageThreshold = 1.0
+coverageReporter = ["text", "lcov"]
 
 [install]
 exact = true


### PR DESCRIPTION
This change makes use of https://github.com/ronin-co/actions/pull/1 and reports the code coverage to [Codecov](https://about.codecov.io).