### PR TITLE
Ensure consistent readme badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RONIN Compiler
 
+[![tests](https://img.shields.io/github/actions/workflow/status/ronin-co/compiler/validate.yml?label=tests)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
 [![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler)](https://codecov.io/github/ronin-co/compiler)
 [![install size](https://packagephobia.com/badge?p=@ronin/compiler)](https://packagephobia.com/result?p=@ronin/compiler)
-[![tests](https://img.shields.io/github/actions/workflow/status/ronin-co/compiler/validate.yml?label=tests)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
 
 This package compiles [RONIN queries](https://ronin.co/docs/queries) to [SQLite](https://www.sqlite.org) statements.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RONIN Compiler
 
-[![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler.svg)](https://codecov.io/github/ronin-co/compiler)
+[![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler)](https://codecov.io/github/ronin-co/compiler)
 [![install size](https://packagephobia.com/badge?p=@ronin/compiler)](https://packagephobia.com/result?p=@ronin/compiler)
-[![tests](https://img.shields.io/github/actions/workflow/status/ronin-co/compiler/validate.yml)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
+[![tests](https://img.shields.io/github/actions/workflow/status/ronin-co/compiler/validate.yml?label=tests)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
 
 This package compiles [RONIN queries](https://ronin.co/docs/queries) to [SQLite](https://www.sqlite.org) statements.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RONIN Compiler
 
-[![Tests](https://github.com/ronin-co/compiler/actions/workflows/validate.yml/badge.svg)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
-[![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler.svg?maxAge=2592000)](https://codecov.io/github/ronin-co/compiler?branch=main)
+[![code coverage](https://img.shields.io/codecov/c/github/ronin-co/compiler.svg)](https://codecov.io/github/ronin-co/compiler)
 [![install size](https://packagephobia.com/badge?p=@ronin/compiler)](https://packagephobia.com/result?p=@ronin/compiler)
+[![tests](https://img.shields.io/github/actions/workflow/status/ronin-co/compiler/validate.yml)](https://github.com/ronin-co/compiler/actions/workflows/validate.yml)
 
 This package compiles [RONIN queries](https://ronin.co/docs/queries) to [SQLite](https://www.sqlite.org) statements.
 


### PR DESCRIPTION
This change ensures the same consistent style for all readme badges:

![CleanShot 2024-12-31 at 11 25 30@2x](https://github.com/user-attachments/assets/efc7e7a3-47f9-4c95-ad60-09353ec111e2)

Note that the last badge is currently intentionally automatically using a slightly yellowish green, since it gets more yellowish the larger the install size of the package is.