### PR TITLE
Avoid using params for schema statements

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1018,7 +1018,6 @@ export const transformMetaQuery = (
     const index = jsonValue as ModelIndex;
     const indexName = convertToSnakeCase(slug);
 
-    const params: Array<unknown> = [];
     let statement = `${statementAction}${index?.unique ? ' UNIQUE' : ''} INDEX "${indexName}"`;
 
     if (action === 'create') {
@@ -1049,18 +1048,17 @@ export const transformMetaQuery = (
       // If filtering instructions were defined, add them to the index. Those
       // instructions will determine which records are included as part of the index.
       if (index.filter) {
-        const withStatement = handleWith(models, existingModel, params, index.filter);
+        const withStatement = handleWith(models, existingModel, null, index.filter);
         statement += ` WHERE (${withStatement})`;
       }
     }
 
-    dependencyStatements.push({ statement, params });
+    dependencyStatements.push({ statement, params: [] });
   }
 
   if (entity === 'trigger') {
     const triggerName = convertToSnakeCase(slug);
 
-    const params: Array<unknown> = [];
     let statement = `${statementAction} TRIGGER "${triggerName}"`;
 
     if (action === 'create') {
@@ -1131,7 +1129,7 @@ export const transformMetaQuery = (
       statement += ` ${statementParts.join(' ')}`;
     }
 
-    dependencyStatements.push({ statement, params });
+    dependencyStatements.push({ statement, params: [] });
   }
 
   const field = `${QUERY_SYMBOLS.FIELD}${pluralType}`;

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1109,7 +1109,7 @@ export const transformMetaQuery = (
         const withStatement = handleWith(
           models,
           { ...existingModel, tableAlias: tableAlias },
-          params,
+          null,
           trigger.filter,
         );
 
@@ -1118,7 +1118,7 @@ export const transformMetaQuery = (
 
       // Compile the effect queries into SQL statements.
       const effectStatements = trigger.effects.map((effectQuery) => {
-        return compileQueryInput(effectQuery, models, params, {
+        return compileQueryInput(effectQuery, models, null, {
           returning: false,
           parentModel: existingModel,
         }).main.statement;

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -938,9 +938,8 @@ test('create new index with filter', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE INDEX "index_slug" ON "accounts" ("email") WHERE (("email" LIKE ?1))',
-      params: ['%@site.co'],
+      statement: `CREATE INDEX "index_slug" ON "accounts" ("email") WHERE (("email" LIKE '%@site.co'))`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1171,7 +1171,7 @@ test('create new trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER \"trigger_slug\" AFTER INSERT ON \"accounts\" BEGIN INSERT INTO \"signups\" (\"year\", \"id\") VALUES ('2000', 'sig_vo0fxfmuyq227hgb'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES ('2000', 'sig_vo0fxfmuyq227hgb'); END`,
       params: [],
     },
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1138,6 +1138,7 @@ test('create new trigger for creating records', () => {
           signup: {
             to: {
               year: 2000,
+              id: 'sig_vo0fxfmuyq227hgb',
             },
           },
         },
@@ -1170,9 +1171,8 @@ test('create new trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES (?1, ?2); END',
-      params: [2000, expect.stringMatching(RECORD_ID_REGEX)],
+      statement: `CREATE TRIGGER \"trigger_slug\" AFTER INSERT ON \"accounts\" BEGIN INSERT INTO \"signups\" (\"year\", \"id\") VALUES ('2000', 'sig_vo0fxfmuyq227hgb'); END`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,
@@ -1192,6 +1192,7 @@ test('create new trigger for creating records with targeted fields', () => {
           signup: {
             to: {
               year: 2000,
+              id: 'sig_iiqimjelgft0tx1r',
             },
           },
         },
@@ -1230,9 +1231,8 @@ test('create new trigger for creating records with targeted fields', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE TRIGGER "trigger_slug" AFTER UPDATE OF ("email") ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES (?1, ?2); END',
-      params: [2000, expect.stringMatching(RECORD_ID_REGEX)],
+      statement: `CREATE TRIGGER "trigger_slug" AFTER UPDATE OF ("email") ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES ('2000', 'sig_iiqimjelgft0tx1r'); END`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,
@@ -1252,6 +1252,7 @@ test('create new trigger for creating records with multiple effects', () => {
           signup: {
             to: {
               year: 2000,
+              id: 'sig_rq4i2ww9trefxeva',
             },
           },
         },
@@ -1261,6 +1262,7 @@ test('create new trigger for creating records with multiple effects', () => {
           candidate: {
             to: {
               year: 2020,
+              id: 'can_hga5r5kkkb3fsojl',
             },
           },
         },
@@ -1297,14 +1299,8 @@ test('create new trigger for creating records with multiple effects', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES (?1, ?2); INSERT INTO "candidates" ("year", "id") VALUES (?3, ?4); END',
-      params: [
-        2000,
-        expect.stringMatching(RECORD_ID_REGEX),
-        2020,
-        expect.stringMatching(RECORD_ID_REGEX),
-      ],
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year", "id") VALUES ('2000', 'sig_rq4i2ww9trefxeva'); INSERT INTO "candidates" ("year", "id") VALUES ('2020', 'can_hga5r5kkkb3fsojl'); END`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,
@@ -1328,6 +1324,7 @@ test('create new per-record trigger for creating records', () => {
               },
               role: 'owner',
               pending: false,
+              id: 'mem_ukbxnq8b5u17k5fy',
             },
           },
         },
@@ -1370,9 +1367,8 @@ test('create new per-record trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending", "id") VALUES (NEW."createdBy", ?1, ?2, ?3); END',
-      params: ['owner', 0, expect.stringMatching(RECORD_ID_REGEX)],
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending", "id") VALUES (NEW."createdBy", 'owner', 'false', 'mem_ukbxnq8b5u17k5fy'); END`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,
@@ -1462,6 +1458,7 @@ test('create new per-record trigger with filters for creating records', () => {
               },
               role: 'owner',
               pending: false,
+              id: 'mem_qvorn0jko4oj4uv3',
             },
           },
         },
@@ -1507,9 +1504,8 @@ test('create new per-record trigger with filters for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN ((NEW."handle" LIKE ?1)) BEGIN INSERT INTO "members" ("account", "role", "pending", "id") VALUES (NEW."createdBy", ?2, ?3, ?4); END',
-      params: ['%_hidden', 'owner', 0, expect.stringMatching(RECORD_ID_REGEX)],
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN ((NEW."handle" LIKE '%_hidden')) BEGIN INSERT INTO "members" ("account", "role", "pending", "id") VALUES (NEW."createdBy", 'owner', 'false', 'mem_qvorn0jko4oj4uv3'); END`,
+      params: [],
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,


### PR DESCRIPTION
SQLite does not support statement parameters in schema statements, which is currently blocking a [different PR](https://github.com/ronin-co/cli/actions/runs/12572461587/job/35044473783), so we have to stop using them for indexes and triggers.

- https://github.com/sqlite/sqlite/blob/f7fcf7f910dcbc765eac670d74f36ccddbfe81c3/src/attach.c#L453
- https://github.com/sqlite/sqlite/blob/f7fcf7f910dcbc765eac670d74f36ccddbfe81c3/src/attach.c#L515
- https://github.com/sqlite/sqlite/blob/f7fcf7f910dcbc765eac670d74f36ccddbfe81c3/test/triggerE.test#L50

Since schema-altering statements like trigger creation, index creation and so on are anyways not run by end-users, the SQLite team likely intentionally didn't want to prevent SQL injections here. Those kinds of queries are also not run repeatedly, so the performance optimization of needing to prepare statements with different values is also not helpful in those cases.