### PR TITLE
Separate field attributes based on type

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -15,8 +15,6 @@ export type ModelFieldLinkAction =
   | 'NO ACTION';
 
 type ModelFieldBasics = {
-  /** The kind of value that should be stored inside the field. */
-  type?: 'boolean' | 'date' | 'json';
   /** The label that should be used when displaying the field on the RONIN dashboard. */
   name?: string;
   /** Allows for addressing the field programmatically. */
@@ -52,24 +50,27 @@ type ModelFieldBasics = {
 };
 
 export type ModelField =
-  | ModelFieldBasics
-  | (Omit<ModelFieldBasics, 'type'> & {
+  | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type: 'string';
+      type?: 'boolean' | 'date' | 'json';
+    })
+  | (ModelFieldBasics & {
+      /** The kind of value that should be stored inside the field. */
+      type?: 'string';
       /** The collation sequence to use for the field value. */
       collation?: ModelFieldCollation;
     })
-  | (Omit<ModelFieldBasics, 'type'> & {
+  | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type: 'number';
+      type?: 'number';
       /**
        * Automatically increments the value of the field with every new inserted record.
        */
       increment?: boolean;
     })
-  | (Omit<ModelFieldBasics, 'type'> & {
+  | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type: 'link';
+      type?: 'link';
       /** The target model of the relationship that is being established. */
       target: string;
       /** Whether the field should be related to one record, or many records. */

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -7,7 +7,16 @@ import type {
 
 type ModelFieldCollation = 'BINARY' | 'NOCASE' | 'RTRIM';
 
+export type ModelFieldLinkAction =
+  | 'CASCADE'
+  | 'RESTRICT'
+  | 'SET NULL'
+  | 'SET DEFAULT'
+  | 'NO ACTION';
+
 type ModelFieldBasics = {
+  /** The kind of value that should be stored inside the field. */
+  type?: 'boolean' | 'date' | 'json';
   /** The label that should be used when displaying the field on the RONIN dashboard. */
   name?: string;
   /** Allows for addressing the field programmatically. */
@@ -40,40 +49,39 @@ type ModelFieldBasics = {
   };
   /** An expression that gets evaluated every time a value is provided for the field. */
   check?: Expression;
-  /**
-   * If the field is of type `string`, setting this attribute defines the collation
-   * sequence to use for the field value.
-   */
-  collation?: ModelFieldCollation;
-  /**
-   * If the field is of type `number`, setting this attribute will automatically increment
-   * the value of the field with every new record that gets inserted.
-   */
-  increment?: boolean;
 };
 
-type ModelFieldNormal = ModelFieldBasics & {
-  type?: 'string' | 'number' | 'boolean' | 'date' | 'json';
-};
-
-export type ModelFieldReferenceAction =
-  | 'CASCADE'
-  | 'RESTRICT'
-  | 'SET NULL'
-  | 'SET DEFAULT'
-  | 'NO ACTION';
-
-export type ModelFieldReference = ModelFieldBasics & {
-  type: 'link';
-  target: string;
-  kind?: 'one' | 'many';
-  actions?: {
-    onDelete?: ModelFieldReferenceAction;
-    onUpdate?: ModelFieldReferenceAction;
-  };
-};
-
-export type ModelField = ModelFieldNormal | ModelFieldReference;
+export type ModelField =
+  | ModelFieldBasics
+  | (Omit<ModelFieldBasics, 'type'> & {
+      /** The kind of value that should be stored inside the field. */
+      type: 'string';
+      /** The collation sequence to use for the field value. */
+      collation?: ModelFieldCollation;
+    })
+  | (Omit<ModelFieldBasics, 'type'> & {
+      /** The kind of value that should be stored inside the field. */
+      type: 'number';
+      /**
+       * Automatically increments the value of the field with every new inserted record.
+       */
+      increment?: boolean;
+    })
+  | (Omit<ModelFieldBasics, 'type'> & {
+      /** The kind of value that should be stored inside the field. */
+      type: 'link';
+      /** The target model of the relationship that is being established. */
+      target: string;
+      /** Whether the field should be related to one record, or many records. */
+      kind?: 'one' | 'many';
+      /**
+       * If the target record is updated or deleted, the defined actions maybe executed.
+       */
+      actions?: {
+        onDelete?: ModelFieldLinkAction;
+        onUpdate?: ModelFieldLinkAction;
+      };
+    });
 
 export type ModelIndexField<T extends Array<ModelField> = Array<ModelField>> = {
   /** The collating sequence used for text placed inside the field. */

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -3,7 +3,7 @@ import type {
   Model,
   ModelEntity,
   ModelField,
-  ModelFieldReferenceAction,
+  ModelFieldLinkAction,
   ModelIndex,
   ModelPreset,
   ModelTrigger,
@@ -614,8 +614,13 @@ const getFieldStatement = (
     statement += ` DEFAULT ${value}`;
   }
 
-  if (field.collation) statement += ` COLLATE ${field.collation}`;
-  if (field.increment === true) statement += ' AUTOINCREMENT';
+  if (field.type === 'string' && field.collation) {
+    statement += ` COLLATE ${field.collation}`;
+  }
+
+  if (field.type === 'number' && field.increment === true) {
+    statement += ' AUTOINCREMENT';
+  }
 
   if (typeof field.check !== 'undefined') {
     const symbol = getSymbol(field.check);
@@ -648,9 +653,7 @@ const getFieldStatement = (
       if (!Object.hasOwn(actions, trigger)) continue;
 
       const triggerName = trigger.toUpperCase().slice(2);
-      const action = actions[
-        trigger as keyof typeof actions
-      ] as ModelFieldReferenceAction;
+      const action = actions[trigger as keyof typeof actions] as ModelFieldLinkAction;
 
       statement += ` ON ${triggerName} ${action}`;
     }


### PR DESCRIPTION
This change ensures that the `ModelField` type changes which attributes are available based on the field type.