### PR TITLE
Ensure correct field type

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -52,17 +52,21 @@ type ModelFieldBasics = {
 export type ModelField =
   | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type?: 'boolean' | 'date' | 'json';
+      type?: never;
     })
   | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type?: 'string';
+      type: 'boolean' | 'date' | 'json';
+    })
+  | (ModelFieldBasics & {
+      /** The kind of value that should be stored inside the field. */
+      type: 'string';
       /** The collation sequence to use for the field value. */
       collation?: ModelFieldCollation;
     })
   | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type?: 'number';
+      type: 'number';
       /**
        * Automatically increments the value of the field with every new inserted record.
        */
@@ -70,7 +74,7 @@ export type ModelField =
     })
   | (ModelFieldBasics & {
       /** The kind of value that should be stored inside the field. */
-      type?: 'link';
+      type: 'link';
       /** The target model of the relationship that is being established. */
       target: string;
       /** Whether the field should be related to one record, or many records. */

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -491,9 +491,9 @@ test('query a model that was just dropped', () => {
 });
 
 test('create new field', () => {
+  // Fields don't need to have a type when being created. The default type is "string".
   const field: ModelField = {
     slug: 'email',
-    type: 'string',
   };
 
   const queries: Array<Query> = [
@@ -522,7 +522,7 @@ test('create new field', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?2) RETURNING *`,
-      params: [JSON.stringify({ ...field, name: 'Email' }), 'account'],
+      params: [JSON.stringify({ ...field, type: 'string', name: 'Email' }), 'account'],
       returning: true,
     },
   ]);


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/compiler/pull/93 and ensures that `Extract` works:

```typescript
type LinkField = Extract<ModelField, { type: 'link' };
```