### PR TITLE
Correctly handle empty fields

### DIFF
--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -163,9 +163,13 @@ export const composeFieldValues = (
   // Determine if the value of the field is a symbol.
   const symbol = getSymbol(value);
 
+  let conditionMatcher = '=';
+  let conditionValue: unknown = value;
+
   // Obtain the SQL syntax that should be used for the current condition.
-  const syntax = WITH_CONDITIONS[options.condition || 'being'](value);
-  let conditionValue = syntax[1];
+  if (options.condition) {
+    [conditionMatcher, conditionValue] = WITH_CONDITIONS[options.condition](value);
+  }
 
   if (symbol) {
     // The value of the field is a RONIN expression, which we need to compile into an SQL
@@ -193,7 +197,7 @@ export const composeFieldValues = (
   if (options.type === 'fields') return conditionSelector;
   if (options.type === 'values') return conditionValue as string;
 
-  return `${conditionSelector} ${syntax[0]} ${conditionValue}`;
+  return `${conditionSelector} ${conditionMatcher} ${conditionValue}`;
 };
 
 /**


### PR DESCRIPTION
This change ensures that, if a field is set to `null`, a correct SQL statement is generated.