### PR TITLE
Support retrieving multiple records with multiple nested records

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,9 @@ class Transaction {
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
       const row = rows[rowIndex];
 
+      if (!records[rowIndex]) records[rowIndex] = {} as Record;
+      let existingRecord = records[rowIndex];
+
       for (let valueIndex = 0; valueIndex < row.length; valueIndex++) {
         const value = row[valueIndex];
         const field = fields[valueIndex];
@@ -156,10 +159,6 @@ class Transaction {
         const parentFieldSlug = (field as ModelField & { parentField?: string })
           .parentField;
 
-        let usableRowIndex = rowIndex;
-        if (!records[usableRowIndex]) records[usableRowIndex] = {} as Record;
-        let existingRecord = records[usableRowIndex];
-
         if (parentFieldSlug) {
           // If the field is nested into a parent field and only one row is available,
           // prefix the current field with the slug of the parent field, which causes it
@@ -173,8 +172,7 @@ class Transaction {
           // fill it with the respective joined records.
           else {
             newSlug = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
-            usableRowIndex = 0;
-            existingRecord = records[usableRowIndex];
+            existingRecord = records[0];
           }
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,7 @@ class Transaction {
           .parentField;
 
         let usableRowIndex = rowIndex;
+        if (!records[usableRowIndex]) records[usableRowIndex] = {};
         let existingRecord = records[usableRowIndex];
 
         if (parentFieldSlug) {
@@ -193,7 +194,7 @@ class Transaction {
             : [];
         }
 
-        records[usableRowIndex] = setProperty<Record>(existingRecord, newSlug, newValue);
+        setProperty<Record>(existingRecord, newSlug, newValue);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,22 @@ class Transaction {
           newValue = Boolean(newValue);
         }
 
+        // If the query is used to alter the database schema, the result of the query
+        // will always be a model, because the only available queries for altering the
+        // database schema are `create.model`, `alter.model`, and `drop.model`. That means
+        // we need to ensure that the resulting record always matches the `Model` type,
+        // by formatting its fields accordingly.
+        if (
+          isMeta &&
+          (PLURAL_MODEL_ENTITIES_VALUES as ReadonlyArray<string>).includes(slug)
+        ) {
+          newValue = newValue
+            ? Object.entries(newValue as object).map(([slug, attributes]) => {
+                return { slug, ...attributes };
+              })
+            : [];
+        }
+
         setProperty(acc, slug, newValue);
         return acc;
       }, {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,24 @@ class Transaction {
       if (!records[rowIndex]) records[rowIndex] = {} as Record;
       let existingRecord = records[rowIndex];
 
+      const rowAsObject = fields.reduce((acc, field, fieldIndex) => {
+        const parentField = 'parentField' in field ? field.parentField : 'root';
+
+        let newValue = row[fieldIndex];
+
+        if (field.type === 'json') {
+          newValue = JSON.parse(newValue as string);
+        } else if (field.type === 'boolean') {
+          newValue = Boolean(newValue);
+        }
+
+        if (!acc[parentField]) acc[parentField] = {};
+        acc[parentField][field.slug] = newValue;
+        return acc;
+      }, {});
+
+      console.log('ROW', rowAsObject);
+
       for (let valueIndex = 0; valueIndex < row.length; valueIndex++) {
         const value = row[valueIndex];
         const field = fields[valueIndex];

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ class Transaction {
           .parentField;
 
         let usableRowIndex = rowIndex;
-        if (!records[usableRowIndex]) records[usableRowIndex] = {};
+        if (!records[usableRowIndex]) records[usableRowIndex] = {} as Record;
         let existingRecord = records[usableRowIndex];
 
         if (parentFieldSlug) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,8 @@ class Transaction {
       let existingRecord = records[rowIndex];
 
       const rowAsObject = fields.reduce((acc, field, fieldIndex) => {
-        const parentField = 'parentField' in field ? field.parentField : 'root';
+        const slug =
+          'parentField' in field ? `${field.parentField}.${field.slug}` : field.slug;
 
         let newValue = row[fieldIndex];
 
@@ -154,8 +155,7 @@ class Transaction {
           newValue = Boolean(newValue);
         }
 
-        if (!acc[parentField]) acc[parentField] = {};
-        acc[parentField][field.slug] = newValue;
+        setProperty(acc, slug, newValue);
         return acc;
       }, {});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,10 +194,7 @@ class Transaction {
         (acc, field) => {
           if (!('parentField' in field)) return acc;
           const { single, slug } = field.parentField;
-
-          if (!(single || acc.includes(slug))) acc.push(field.parentField.slug);
-
-          return acc;
+          return single || acc.includes(slug) ? acc : acc.concat([slug]);
         },
         [] as Array<string>,
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,11 @@ import {
   addDefaultModelFields,
   addDefaultModelPresets,
 } from '@/src/model/defaults';
-import type { ModelField, Model as PrivateModel, PublicModel } from '@/src/types/model';
+import type {
+  InternalModelField,
+  Model as PrivateModel,
+  PublicModel,
+} from '@/src/types/model';
 import type { InternalStatement, Query, Statement } from '@/src/types/query';
 import type {
   MultipleRecordResult,
@@ -117,20 +121,20 @@ class Transaction {
   };
 
   #formatRows<Record = NativeRecord>(
-    fields: Array<ModelField>,
+    fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: true,
     isMeta: boolean,
   ): Record;
   #formatRows<Record = NativeRecord>(
-    fields: Array<ModelField>,
+    fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: false,
     isMeta: boolean,
   ): Array<Record>;
 
   #formatRows<Record = NativeRecord>(
-    fields: Array<ModelField>,
+    fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: boolean,
     isMeta: boolean,
@@ -142,7 +146,7 @@ class Transaction {
         let newSlug = field.slug;
         let newValue = row[fieldIndex];
 
-        if ('parentField' in field) {
+        if (field.parentField) {
           const arrayKey = field.parentField.single ? '' : '[0]';
           newSlug = `${field.parentField.slug}${arrayKey}.${field.slug}`;
         }
@@ -192,7 +196,7 @@ class Transaction {
 
       const joinFields = fields.reduce(
         (acc, field) => {
-          if (!('parentField' in field)) return acc;
+          if (!field.parentField) return acc;
           const { single, slug } = field.parentField;
           return single || acc.includes(slug) ? acc : acc.concat([slug]);
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,7 @@ class Transaction {
           .parentField;
 
         let usableRowIndex = rowIndex;
+        let existingRecord = records[usableRowIndex];
 
         if (parentFieldSlug) {
           // If the field is nested into a parent field and only one row is available,
@@ -172,6 +173,7 @@ class Transaction {
           else {
             newSlug = `${parentFieldSlug}[${rowIndex}].${field.slug}`;
             usableRowIndex = 0;
+            existingRecord = records[usableRowIndex];
           }
         }
 
@@ -191,22 +193,18 @@ class Transaction {
             : [];
         }
 
-        records[usableRowIndex] = setProperty<Record>(
-          records[usableRowIndex],
-          newSlug,
-          newValue,
-        );
+        records[usableRowIndex] = setProperty<Record>(existingRecord, newSlug, newValue);
       }
     }
 
     return single ? records[0] : records;
   }
 
-  formatResults<Record>(results: Array<Array<RawRow>>, raw?: true): Array<Result<Record>>;
   formatResults<Record>(
     results: Array<Array<ObjectRow>>,
     raw?: false,
   ): Array<Result<Record>>;
+  formatResults<Record>(results: Array<Array<RawRow>>, raw?: true): Array<Result<Record>>;
 
   /**
    * Format the results returned from the database into RONIN records.
@@ -278,7 +276,7 @@ class Transaction {
         if (single) {
           return {
             record: rows[0]
-              ? this.#formatRows<Record>(rawModelFields, rows, single, isMeta)
+              ? this.#formatRows<Record>(rawModelFields, rows, true, isMeta)
               : null,
             modelFields,
           };
@@ -288,7 +286,7 @@ class Transaction {
 
         // The query is targeting multiple records.
         const output: MultipleRecordResult<Record> = {
-          records: this.#formatRows<Record>(rawModelFields, rows, single, isMeta),
+          records: this.#formatRows<Record>(rawModelFields, rows, false, isMeta),
           modelFields,
         };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,9 +170,11 @@ class Transaction {
         return acc;
       }, {} as NativeRecord);
 
-      const existingRecord = records.find((existingRecord) => {
-        return existingRecord.id === record.id;
-      });
+      const existingRecord = record.id
+        ? records.find((existingRecord) => {
+            return existingRecord.id === record.id;
+          })
+        : null;
 
       // In the most common scenario that there isn't already a record with the same ID
       // as the current row, we can simply add the record to the list of records.

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -104,6 +104,19 @@ export const handleSelecting = (
               return !(field.type === 'link' && field.kind === 'many');
             });
 
+        const loadedFieldIndex = loadedFields.findIndex((field) => field.slug === key);
+        const loadedField = {
+          slug: key,
+          type: subSingle ? 'record' : 'records',
+        } as unknown as ModelField;
+
+        // Ensure an internal field that represents the joined record or records.
+        if (loadedFieldIndex > 0) {
+          loadedFields[loadedFieldIndex] = loadedField;
+        } else {
+          loadedFields.push(loadedField);
+        }
+
         for (const field of queryModelFields) {
           loadedFields.push({ ...field, parentField: key } as unknown as ModelField);
 

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -18,6 +18,7 @@ import { parseFieldExpression, prepareStatementValue } from '@/src/utils/stateme
  *
  * @param models - A list of models.
  * @param model - The model associated with the current query.
+ * @param single - Whether a single or multiple records are being queried.
  * @param statementParams - A collection of values that will automatically be
  * inserted into the query by SQLite.
  * @param instructions - The instructions associated with the current query.
@@ -29,6 +30,7 @@ export const handleSelecting = (
   models: Array<Model>,
   model: Model,
   statementParams: Array<unknown> | null,
+  single: boolean,
   instructions: {
     selecting: Instructions['selecting'];
     including: Instructions['including'];
@@ -84,12 +86,12 @@ export const handleSelecting = (
         expandColumns = Boolean(options?.expandColumns || queryInstructions?.selecting);
 
         const tableAlias = composeIncludedTableAlias(key);
-        const single = queryModel !== subQueryModel.pluralSlug;
+        const subSingle = queryModel !== subQueryModel.pluralSlug;
 
         // If multiple records are being joined and the root query only targets a single
         // record, we need to alias the root table, because it will receive a dedicated
         // SELECT statement in the `handleIncluding` function.
-        if (!single) {
+        if (single && !subSingle) {
           model.tableAlias = `sub_${model.table}`;
         }
 

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -1,5 +1,5 @@
 import { getFieldFromModel, getModelBySlug } from '@/src/model';
-import type { Model, ModelField } from '@/src/types/model';
+import type { InternalModelField, Model, ModelField } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
 import {
   QUERY_SYMBOLS,
@@ -39,8 +39,8 @@ export const handleSelecting = (
     /** Alias column names that are duplicated when joining multiple tables. */
     expandColumns?: boolean;
   },
-): { columns: string; isJoining: boolean; loadedFields: Array<ModelField> } => {
-  let loadedFields: Array<ModelField> = [];
+): { columns: string; isJoining: boolean; loadedFields: Array<InternalModelField> } => {
+  let loadedFields: Array<InternalModelField> = [];
   let expandColumns = false;
 
   let statement = '*';
@@ -111,7 +111,7 @@ export const handleSelecting = (
               slug: key,
               single: subSingle,
             },
-          } as unknown as ModelField);
+          });
 
           // If the column names should be expanded, that means we need to alias all
           // columns of the joined table to avoid conflicts with the root table.

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -104,21 +104,14 @@ export const handleSelecting = (
               return !(field.type === 'link' && field.kind === 'many');
             });
 
-        const loadedFieldIndex = loadedFields.findIndex((field) => field.slug === key);
-        const loadedField = {
-          slug: key,
-          type: subSingle ? 'record' : 'records',
-        } as unknown as ModelField;
-
-        // Ensure an internal field that represents the joined record or records.
-        if (loadedFieldIndex > 0) {
-          loadedFields[loadedFieldIndex] = loadedField;
-        } else {
-          loadedFields.push(loadedField);
-        }
-
         for (const field of queryModelFields) {
-          loadedFields.push({ ...field, parentField: key } as unknown as ModelField);
+          loadedFields.push({
+            ...field,
+            parentField: {
+              slug: key,
+              single: subSingle,
+            },
+          } as unknown as ModelField);
 
           // If the column names should be expanded, that means we need to alias all
           // columns of the joined table to avoid conflicts with the root table.

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -103,6 +103,20 @@ export type ModelField = ModelFieldBasics &
       }
   );
 
+/** An extended version of `ModelField`, for internal use within the compiler. */
+export type InternalModelField = ModelField & {
+  /**
+   * Whether the field should be mounted onto a field higher up in the tree during the
+   * formatting of the database results.
+   */
+  parentField?: {
+    /** The slug of the parent field. */
+    slug: string;
+    /** Whether a single record is being mounted onto the parent field, or multiple. */
+    single: boolean;
+  };
+};
+
 export type ModelIndexField<T extends Array<ModelField> = Array<ModelField>> = {
   /** The collating sequence used for text placed inside the field. */
   collation?: ModelFieldCollation;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -360,21 +360,19 @@ export const getProperty = (obj: NestedObject, path: string): unknown => {
 };
 
 /**
- * Sets a property on an object and returns the object with the property set.
+ * Sets a property on an object by mutating the object in place.
  *
  * @param obj - The object on which the property should be set.
  * @param path - The path at which the property should be set.
  * @param value - The value of the property.
  *
- * @returns The object with the property set.
+ * @returns Nothing.
  */
 export const setProperty = <Object = NestedObject>(
   obj: Object,
   path: string,
   value: unknown,
-): Object => {
-  if (!obj) return setProperty({} as Object, path, value);
-
+): void => {
   const segments = path.split(/[.[\]]/g).filter((x) => !!x.trim());
 
   const _set = (node: NestedObject): void => {
@@ -393,9 +391,7 @@ export const setProperty = <Object = NestedObject>(
     }
   };
 
-  const cloned = structuredClone(obj);
-  _set(cloned);
-  return cloned;
+  _set(obj as NestedObject);
 };
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@ import { handleSelecting } from '@/src/instructions/selecting';
 import { handleTo } from '@/src/instructions/to';
 import { handleWith } from '@/src/instructions/with';
 import { getModelBySlug, transformMetaQuery } from '@/src/model';
-import type { Model, ModelField } from '@/src/types/model';
+import type { InternalModelField, Model } from '@/src/types/model';
 import type { Query, Statement } from '@/src/types/query';
 import { RoninError, isObject, splitQuery } from '@/src/utils/helpers';
 import { formatIdentifiers } from '@/src/utils/statement';
@@ -47,7 +47,7 @@ export const compileQueryInput = (
 ): {
   dependencies: Array<Statement>;
   main: Statement;
-  loadedFields: Array<ModelField>;
+  loadedFields: Array<InternalModelField>;
 } => {
   // A list of write statements that are required to be executed before the main read
   // statement. Their output is not relevant for the main statement, as they are merely

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,6 +94,7 @@ export const compileQueryInput = (
     models,
     model,
     statementParams,
+    single,
     {
       selecting: instructions?.selecting,
       including: instructions?.including,
@@ -132,6 +133,7 @@ export const compileQueryInput = (
       models,
       model,
       statementParams,
+      single,
       instructions?.including,
     );
 

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -44,12 +44,12 @@ const prefillDatabase = async (
       const data = fixtureData[fixtureSlug] || [];
 
       const formattedData = data.map((row) => {
-        let newRow: Record<string, unknown> = {};
+        const newRow: Record<string, unknown> = {};
 
         for (const field of createdModel.fields || []) {
           const match = getProperty(row, field.slug);
           if (typeof match === 'undefined') continue;
-          newRow = setProperty(newRow, field.slug, match);
+          setProperty(newRow, field.slug, match);
         }
 
         return newRow;

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -351,8 +351,9 @@ test('get multiple records including unrelated records with filter', async () =>
     },
   ];
 
-  const transaction = new Transaction(queries, { models });
+  const transaction = new Transaction(queries, { models, expandColumns: true });
 
+  /*
   expect(transaction.statements).toEqual([
     {
       statement: `SELECT * FROM "accounts" LEFT JOIN "members" as including_members ON ("including_members"."account" = "accounts"."id")`,
@@ -360,9 +361,10 @@ test('get multiple records including unrelated records with filter', async () =>
       returning: true,
     },
   ]);
+  */
 
-  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements, false);
+  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
   expect(result.records).toEqual([
     {
@@ -374,7 +376,7 @@ test('get multiple records including unrelated records with filter', async () =>
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         updatedBy: null,
       },
-      members: new Array(4).fill({
+      members: new Array(2).fill({
         account: expect.stringMatching(RECORD_ID_REGEX),
         id: expect.stringMatching(RECORD_ID_REGEX),
         ronin: {
@@ -395,16 +397,19 @@ test('get multiple records including unrelated records with filter', async () =>
         updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
         updatedBy: null,
       },
-    },
-    {
-      id: expect.stringMatching(RECORD_ID_REGEX),
-      ronin: {
-        locked: false,
-        createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        createdBy: null,
-        updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-        updatedBy: null,
-      },
+      members: [
+        {
+          account: expect.stringMatching(RECORD_ID_REGEX),
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            locked: false,
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        },
+      ],
     },
   ]);
 });

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -351,9 +351,8 @@ test('get multiple records including unrelated records with filter', async () =>
     },
   ];
 
-  const transaction = new Transaction(queries, { models, expandColumns: true });
+  const transaction = new Transaction(queries, { models });
 
-  /*
   expect(transaction.statements).toEqual([
     {
       statement: `SELECT * FROM "accounts" LEFT JOIN "members" as including_members ON ("including_members"."account" = "accounts"."id")`,
@@ -361,10 +360,9 @@ test('get multiple records including unrelated records with filter', async () =>
       returning: true,
     },
   ]);
-  */
 
-  const rawResults = await queryEphemeralDatabase(models, transaction.statements, false);
-  const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;
 
   expect(result.records).toEqual([
     {

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -366,6 +366,8 @@ test('get multiple records including unrelated records with filter', async () =>
   const rawResults = await queryEphemeralDatabase(models, transaction.statements, false);
   const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
+  console.log('RAW RESULTS', rawResults);
+
   expect(result.records).toEqual([
     {
       id: expect.stringMatching(RECORD_ID_REGEX),

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -366,8 +366,6 @@ test('get multiple records including unrelated records with filter', async () =>
   const rawResults = await queryEphemeralDatabase(models, transaction.statements, false);
   const result = transaction.formatResults(rawResults, false)[0] as MultipleRecordResult;
 
-  console.log('RAW RESULTS', rawResults);
-
   expect(result.records).toEqual([
     {
       id: expect.stringMatching(RECORD_ID_REGEX),


### PR DESCRIPTION
Previously, it was only possible to include multiple nested records when retrieving a single root record.

With the current change, it is now possible to include multiple nested records per root record, even when retrieving multiple root records.