### PR TITLE
Export function for detecting query symbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -390,4 +390,4 @@ const CLEAN_ROOT_MODEL = omit(ROOT_MODEL, ['system']) as PublicModel;
 export { Transaction, CLEAN_ROOT_MODEL as ROOT_MODEL };
 
 // Expose the main error class and query symbols
-export { RoninError, QUERY_SYMBOLS } from '@/src/utils/helpers';
+export { RoninError, QUERY_SYMBOLS, getQuerySymbol } from '@/src/utils/helpers';

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -2,7 +2,11 @@ import type { WithFilters } from '@/src/instructions/with';
 import { getModelBySlug } from '@/src/model';
 import type { Model } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
-import { composeIncludedTableAlias, getSymbol, splitQuery } from '@/src/utils/helpers';
+import {
+  composeIncludedTableAlias,
+  getQuerySymbol,
+  splitQuery,
+} from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
 import { composeConditions } from '@/src/utils/statement';
 
@@ -35,7 +39,7 @@ export const handleIncluding = (
   for (const ephemeralFieldSlug in instruction) {
     if (!Object.hasOwn(instruction, ephemeralFieldSlug)) continue;
 
-    const symbol = getSymbol(instruction[ephemeralFieldSlug]);
+    const symbol = getQuerySymbol(instruction[ephemeralFieldSlug]);
 
     // The `including` instruction might contain values that are not queries, which are
     // taken care of by the `handleSelecting` function. Specifically, those values are

--- a/src/instructions/ordered-by.ts
+++ b/src/instructions/ordered-by.ts
@@ -1,7 +1,7 @@
 import { getFieldFromModel } from '@/src/model';
 import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
-import { getSymbol } from '@/src/utils/helpers';
+import { getQuerySymbol } from '@/src/utils/helpers';
 import { parseFieldExpression } from '@/src/utils/statement';
 
 /**
@@ -29,7 +29,7 @@ export const handleOrderedBy = (
       statement += ', ';
     }
 
-    const symbol = getSymbol(item.value);
+    const symbol = getQuerySymbol(item.value);
     const instructionName =
       item.order === 'ASC' ? 'orderedBy.ascending' : 'orderedBy.descending';
 

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -7,7 +7,7 @@ import {
   type RawFieldType,
   composeIncludedTableAlias,
   flatten,
-  getSymbol,
+  getQuerySymbol,
   splitQuery,
 } from '@/src/utils/helpers';
 import { parseFieldExpression, prepareStatementValue } from '@/src/utils/statement';
@@ -76,7 +76,7 @@ export const handleSelecting = (
   // If additional fields (that are not part of the model) were provided in the
   // `including` instruction, add ephemeral (non-stored) columns for those fields.
   if (instructions.including) {
-    const symbol = getSymbol(instructions.including);
+    const symbol = getQuerySymbol(instructions.including);
 
     if (symbol?.type === 'query') {
       instructions.including.ronin_root = { ...instructions.including };
@@ -93,7 +93,7 @@ export const handleSelecting = (
     // the case of sub queries resulting in multiple records, it's the only way to
     // include multiple rows of another table.
     for (const [key, value] of Object.entries(flatObject)) {
-      const symbol = getSymbol(value);
+      const symbol = getQuerySymbol(value);
 
       // A JOIN is being performed.
       if (symbol?.type === 'query') {

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -8,7 +8,7 @@ import type { FieldValue, SetInstructions, Statement } from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
   flatten,
-  getSymbol,
+  getQuerySymbol,
   isObject,
   splitQuery,
 } from '@/src/utils/helpers';
@@ -56,7 +56,7 @@ export const handleTo = (
   }
 
   // Check whether a query resides at the root of the `to` instruction.
-  const symbol = getSymbol(toInstruction);
+  const symbol = getQuerySymbol(toInstruction);
 
   // If a sub query is provided as the `to` instruction, we don't need to compute a list
   // of fields and/or values for the SQL query, since the fields and values are all

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -30,7 +30,7 @@ import {
   convertToCamelCase,
   convertToSnakeCase,
   findInObject,
-  getSymbol,
+  getQuerySymbol,
   splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
@@ -377,7 +377,7 @@ const getFieldStatement = (
   if (field.required === true) statement += ' NOT NULL';
 
   if (typeof field.defaultValue !== 'undefined') {
-    const symbol = getSymbol(field.defaultValue);
+    const symbol = getQuerySymbol(field.defaultValue);
 
     let value =
       typeof field.defaultValue === 'string'
@@ -397,13 +397,13 @@ const getFieldStatement = (
   }
 
   if (typeof field.check !== 'undefined') {
-    const symbol = getSymbol(field.check);
+    const symbol = getQuerySymbol(field.check);
     statement += ` CHECK (${parseFieldExpression(model, 'to', symbol?.value as string)})`;
   }
 
   if (typeof field.computedAs !== 'undefined') {
     const { kind, value } = field.computedAs;
-    const symbol = getSymbol(value);
+    const symbol = getQuerySymbol(value);
     statement += ` GENERATED ALWAYS AS (${parseFieldExpression(model, 'to', symbol?.value as string)}) ${kind}`;
   }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -224,7 +224,7 @@ export const isObject = (value: unknown): boolean =>
  *
  * @returns The type and value of the symbol, if the provided value contains one.
  */
-export const getSymbol = (
+export const getQuerySymbol = (
   value: unknown,
 ):
   | {
@@ -326,7 +326,7 @@ export const flatten = (
     const path = prefix ? `${prefix}.${key}` : key;
     const value = obj[key];
 
-    if (typeof value === 'object' && value !== null && !getSymbol(value)) {
+    if (typeof value === 'object' && value !== null && !getQuerySymbol(value)) {
       flatten(value as NestedObject, path, res);
     } else {
       res[path] = value;

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -11,7 +11,7 @@ import {
   QUERY_SYMBOLS,
   RONIN_MODEL_FIELD_REGEX,
   RoninError,
-  getSymbol,
+  getQuerySymbol,
   isObject,
 } from '@/src/utils/helpers';
 
@@ -161,7 +161,7 @@ export const composeFieldValues = (
   const collectStatementValue = options.type !== 'fields';
 
   // Determine if the value of the field is a symbol.
-  const symbol = getSymbol(value);
+  const symbol = getQuerySymbol(value);
 
   let conditionMatcher = '=';
   let conditionValue: unknown = value;
@@ -279,7 +279,7 @@ export const composeConditions = (
 
       if (
         (modelField && !(isObject(value) || Array.isArray(value))) ||
-        getSymbol(value) ||
+        getQuerySymbol(value) ||
         consumeJSON
       ) {
         return composeFieldValues(

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -412,6 +412,9 @@ test('get multiple records including unrelated records with filter', async () =>
   ]);
 });
 
+// In this test, the results of the joined table will not be mounted at a dedicated
+// field on the parent record. Instead, the fields of the joined records will be merged
+// into the parent record.
 test('get multiple records including unrelated records with filter (hoisted)', async () => {
   const queries: Array<Query> = [
     {
@@ -687,11 +690,8 @@ test('get multiple records including unrelated records with filter (nested)', as
 });
 
 // In this test, the results of the joined table will not be mounted at a dedicated
-// property on the parent record.
-//
-// Instead, the results will be added to the parent record entirely, which is useful in
-// cases where the parent record only acts as an associative record that links two
-// otherwise unrelated records together, like when using a "many"-cardinality link field.
+// field on the parent record. Instead, the fields of the joined records will be merged
+// into the parent record.
 test('get multiple records including unrelated records with filter (nested, hoisted)', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
This change ensures that the compiler exports a function called `getQuerySymbol`, which allows for determining whether a given value is a query symbol (like an expression or a sub query), or not.