### PR TITLE
Stop implicitly selecting ID

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -66,17 +66,6 @@ export const handleTo = (
       splitQuery(symbol.value);
     const subQueryModel = getModelBySlug(models, subQueryModelSlug);
 
-    // If specific fields were selected by the sub query, we also need to include the
-    // ID field, since we can't generate fresh IDs for every record that is being added
-    // by the sub query, since the ID would have to be generated in JavaScript (due to
-    // the specific ID format RONIN is using) and we don't know how many records will be
-    // added by the sub query.
-    if (subQueryInstructions?.selecting) {
-      const currentFields = new Set(subQueryInstructions.selecting);
-      currentFields.add('id');
-      subQueryInstructions.selecting = Array.from(currentFields);
-    }
-
     const subQuerySelectedFields = subQueryInstructions?.selecting;
     const subQueryIncludedFields = subQueryInstructions?.including;
 

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -915,7 +915,7 @@ test('add multiple records with nested sub query and specific fields', async () 
   expect(transaction.statements).toEqual([
     {
       statement:
-        'INSERT INTO "users" ("handle", "id") SELECT "handle", "id" FROM "accounts" RETURNING *',
+        'INSERT INTO "users" ("handle") SELECT "handle" FROM "accounts" RETURNING *',
       params: [],
       returning: true,
     },
@@ -973,7 +973,7 @@ test('add multiple records with nested sub query and specific meta fields', asyn
   expect(transaction.statements).toEqual([
     {
       statement:
-        'INSERT INTO "users" ("ronin.updatedAt", "id") SELECT "ronin.updatedAt", "id" FROM "accounts" RETURNING *',
+        'INSERT INTO "users" ("ronin.updatedAt") SELECT "ronin.updatedAt" FROM "accounts" RETURNING *',
       params: [],
       returning: true,
     },


### PR DESCRIPTION
As mentioned in the code comment within the PR diff, we previously had to implicitly add the `id` field to the `selecting` instruction in certain cases, but since IDs are now generated in the DB (as of https://github.com/ronin-co/compiler/pull/97), that is no longer necessary.