### PR TITLE
Added patterns for `selecting`

### DIFF
--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -10,7 +10,11 @@ import {
   getQuerySymbol,
   splitQuery,
 } from '@/src/utils/helpers';
-import { parseFieldExpression, prepareStatementValue } from '@/src/utils/statement';
+import {
+  filterSelectedFields,
+  parseFieldExpression,
+  prepareStatementValue,
+} from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `selecting` query instruction, which allows for
@@ -46,15 +50,9 @@ export const handleSelecting = (
 
   // If specific fields were provided in the `selecting` instruction, select only the
   // columns of those fields. Otherwise, select all columns.
-  const selectedFields: Array<InternalModelField> = (
-    instructions.selecting
-      ? instructions.selecting.map((slug) => {
-          const { field } = getFieldFromModel(model, slug, {
-            instructionName: 'selecting',
-          });
-          return field;
-        })
-      : model.fields
+  const selectedFields: Array<InternalModelField> = filterSelectedFields(
+    model,
+    instructions.selecting,
   )
     .filter((field: ModelField) => !(field.type === 'link' && field.kind === 'many'))
     .map((field) => {

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -1,4 +1,14 @@
+import {
+  WITH_CONDITIONS,
+  type WithCondition,
+  type WithFilters,
+  type WithValue,
+  type WithValueOptions,
+} from '@/src/instructions/with';
+import { getFieldFromModel, getModelBySlug } from '@/src/model';
+import type { Model, ModelField } from '@/src/types/model';
 import type {
+  CombinedInstructions,
   FieldSelector,
   GetInstructions,
   Instructions,
@@ -14,16 +24,6 @@ import {
   getQuerySymbol,
   isObject,
 } from '@/src/utils/helpers';
-
-import {
-  WITH_CONDITIONS,
-  type WithCondition,
-  type WithFilters,
-  type WithValue,
-  type WithValueOptions,
-} from '@/src/instructions/with';
-import { getFieldFromModel, getModelBySlug } from '@/src/model';
-import type { Model } from '@/src/types/model';
 import { compileQueryInput } from '@/src/utils/index';
 
 /**
@@ -37,6 +37,19 @@ import { compileQueryInput } from '@/src/utils/index';
 const replaceJSON = (key: string, value: string): unknown => {
   if (key === QUERY_SYMBOLS.EXPRESSION) return value.replaceAll(`'`, `''`);
   return value;
+};
+
+export const filterSelectedFields = (
+  model: Model,
+  instruction: CombinedInstructions['selecting'],
+): Array<ModelField> => {
+  if (!instruction) return model.fields;
+
+  return instruction.map((slug) => {
+    return getFieldFromModel(model, slug, {
+      instructionName: 'selecting',
+    }).field;
+  });
 };
 
 /**

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -39,6 +39,15 @@ const replaceJSON = (key: string, value: string): unknown => {
   return value;
 };
 
+/**
+ * Determines which fields of a model should be selected by a query, based on the value
+ * of a provided `selecting` instruction.
+ *
+ * @param model - The model associated with the current query.
+ * @param instruction - The `selecting` instruction provided in the current query.
+ *
+ * @returns The list of fields that should be selected.
+ */
 export const filterSelectedFields = (
   model: Model,
   instruction: CombinedInstructions['selecting'],

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -45,11 +45,33 @@ export const filterSelectedFields = (
 ): Array<ModelField> => {
   if (!instruction) return model.fields;
 
-  return instruction.map((slug) => {
-    return getFieldFromModel(model, slug, {
+  const selectedFields: Array<ModelField> = [];
+
+  for (const selectedSlug of instruction) {
+    // Add all fields.
+    if (selectedSlug === '*') {
+      selectedFields.push(...model.fields);
+      continue;
+    }
+
+    // Remove particular fields.
+    if (selectedSlug.startsWith('!')) {
+      const fieldSlug = selectedSlug.slice(1);
+      const existingMatch = selectedFields.findIndex((field) => field.slug === fieldSlug);
+
+      selectedFields.splice(existingMatch, 1);
+      continue;
+    }
+
+    // Add a particular field.
+    const field = getFieldFromModel(model, selectedSlug, {
       instructionName: 'selecting',
     }).field;
-  });
+
+    selectedFields.push(field);
+  }
+
+  return selectedFields;
 };
 
 /**

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -89,7 +89,7 @@ test('get single record with all fields except specific ones', async () => {
     {
       get: {
         beach: {
-          selecting: ['*', '!id'],
+          selecting: ['**', '!id'],
         },
       },
     },

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -167,6 +167,88 @@ test('get single record with specific fields (root level, except)', async () => 
   });
 });
 
+test('get single record with specific fields (root level, any prefix)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['*ame'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    name: expect.any(String),
+  });
+});
+
+test('get single record with specific fields (root level, any suffix)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['na*'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    name: expect.any(String),
+  });
+});
+
 test('get single record with specific fields (all levels)', async () => {
   const queries: Array<Query> = [
     {

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from 'bun:test';
-import {
-  RECORD_ID_REGEX,
-  RECORD_TIMESTAMP_REGEX,
-  queryEphemeralDatabase,
-} from '@/fixtures/utils';
+import { RECORD_ID_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
 import type { SingleRecordResult } from '@/src/types/result';
 
@@ -84,12 +80,12 @@ test('get single record with specific fields', async () => {
   });
 });
 
-test('get single record with all fields except specific ones', async () => {
+test('get single record with specific fields (only root level)', async () => {
   const queries: Array<Query> = [
     {
       get: {
         beach: {
-          selecting: ['**', '!id'],
+          selecting: ['*'],
         },
       },
     },
@@ -111,8 +107,7 @@ test('get single record with all fields except specific ones', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'SELECT "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" LIMIT 1',
+      statement: 'SELECT "id", "name" FROM "beaches" LIMIT 1',
       params: [],
       returning: true,
     },
@@ -122,13 +117,7 @@ test('get single record with all fields except specific ones', async () => {
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
-    name: 'Bondi',
-    ronin: {
-      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-      createdBy: null,
-      locked: false,
-      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-      updatedBy: null,
-    },
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    name: expect.any(String),
   });
 });

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -126,6 +126,47 @@ test('get single record with specific fields (root level)', async () => {
   });
 });
 
+test('get single record with specific fields (root level, except)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['*', '!id'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    name: expect.any(String),
+  });
+});
+
 test('get single record with specific fields (all levels)', async () => {
   const queries: Array<Query> = [
     {
@@ -173,47 +214,6 @@ test('get single record with specific fields (all levels)', async () => {
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       updatedBy: null,
     },
-  });
-});
-
-test('get single record with specific fields (root level, except)', async () => {
-  const queries: Array<Query> = [
-    {
-      get: {
-        beach: {
-          selecting: ['*', '!id'],
-        },
-      },
-    },
-  ];
-
-  const models: Array<Model> = [
-    {
-      slug: 'beach',
-      fields: [
-        {
-          slug: 'name',
-          type: 'string',
-        },
-      ],
-    },
-  ];
-
-  const transaction = new Transaction(queries, { models });
-
-  expect(transaction.statements).toEqual([
-    {
-      statement: 'SELECT "name" FROM "beaches" LIMIT 1',
-      params: [],
-      returning: true,
-    },
-  ]);
-
-  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
-
-  expect(result.record).toMatchObject({
-    name: expect.any(String),
   });
 });
 

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -79,3 +79,45 @@ test('get single record with specific fields', async () => {
     name: expect.any(String),
   });
 });
+
+test('get single record with all fields except specific ones', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['*', '!id'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT "id", "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    name: expect.any(String),
+  });
+});

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -216,3 +216,52 @@ test('get single record with specific fields (root level, except)', async () => 
     name: expect.any(String),
   });
 });
+
+test('get single record with specific fields (all levels, except)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['**', '!id'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement:
+        'SELECT "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    name: expect.any(String),
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+  });
+});

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -84,7 +84,7 @@ test('get single record with specific fields', async () => {
   });
 });
 
-test('get single record with specific fields (only root level)', async () => {
+test('get single record with specific fields (root level)', async () => {
   const queries: Array<Query> = [
     {
       get: {
@@ -173,5 +173,46 @@ test('get single record with specific fields (all levels)', async () => {
       updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
       updatedBy: null,
     },
+  });
+});
+
+test('get single record with specific fields (root level, except)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          selecting: ['*', '!id'],
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'name',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: 'SELECT "name" FROM "beaches" LIMIT 1',
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    name: expect.any(String),
   });
 });

--- a/tests/instructions/selecting.test.ts
+++ b/tests/instructions/selecting.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'bun:test';
-import { RECORD_ID_REGEX, queryEphemeralDatabase } from '@/fixtures/utils';
+import {
+  RECORD_ID_REGEX,
+  RECORD_TIMESTAMP_REGEX,
+  queryEphemeralDatabase,
+} from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
 import type { SingleRecordResult } from '@/src/types/result';
 
@@ -107,7 +111,8 @@ test('get single record with all fields except specific ones', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT "id", "name" FROM "beaches" LIMIT 1',
+      statement:
+        'SELECT "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" LIMIT 1',
       params: [],
       returning: true,
     },
@@ -117,7 +122,13 @@ test('get single record with all fields except specific ones', async () => {
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({
-    id: expect.stringMatching(RECORD_ID_REGEX),
-    name: expect.any(String),
+    name: 'Bondi',
+    ronin: {
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      locked: false,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
   });
 });


### PR DESCRIPTION
So far, the `selecting` instruction only allowed for selecting specific fields, like so:

```typescript
get.accounts.selecting(['handle']);
```

With the current change, the instruction is gaining support for [glob](https://en.wikipedia.org/wiki/Glob_(programming))-like patterns, which allows for matching multiple different fields at once, and most importantly also excluding certain fields:

```typescript
// Matches all fields at the root level
get.accounts.selecting(['*']);

// Matches all fields on any level
get.accounts.selecting(['**']);

// Excludes certain fields
get.accounts.selecting(['!handle']);
```

The aforementioned pattern components can then be combined as well. For example, like this:

```typescript
// Matches all fields nested under `ronin`
get.accounts.selecting(['ronin.*']);

// Matches all fields on any level whose name is `item`
get.accounts.selecting(['**.item']);

// Excludes all fields on any level whose name is `item`
get.accounts.selecting(['!**.item']);
```