### PR TITLE
Ensure perfect results for one-to-many relationships

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -13,7 +13,7 @@ import {
   splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
-import { composeConditions } from '@/src/utils/statement';
+import { composeConditions, filterSelectedFields } from '@/src/utils/statement';
 
 /**
  * Generates the SQL syntax for the `to` query instruction, which allows for providing
@@ -71,8 +71,9 @@ export const handleTo = (
 
     // Determine which fields will be returned by the sub query.
     const subQueryFields = [
-      ...(subQuerySelectedFields ||
-        (subQueryModel.fields || []).map((field) => field.slug)),
+      ...filterSelectedFields(subQueryModel, subQuerySelectedFields).map(
+        (field) => field.slug,
+      ),
       ...(subQueryIncludedFields
         ? Object.keys(
             flatten((subQueryIncludedFields || {}) as unknown as Record<string, unknown>),

--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -249,6 +249,8 @@ export const addDefaultModelPresets = (list: Array<Model>, model: Model): Model 
                           },
                         },
                       },
+
+                      selecting: ['**', '!source', '!target'],
                     },
                   },
                 },

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -525,7 +525,7 @@ test('get single record including child records (one-to-many, defined manually)'
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "beaches" LIMIT 1) as sub_beaches LEFT JOIN "ronin_link_beach_visitors" as including_visitors ON ("including_visitors"."source" = "sub_beaches"."id") LEFT JOIN "accounts" as including_ronin_root ON ("including_ronin_root"."id" = "including_visitors"."target")`,
+      statement: `SELECT "sub_beaches"."id", "sub_beaches"."ronin.locked", "sub_beaches"."ronin.createdAt", "sub_beaches"."ronin.createdBy", "sub_beaches"."ronin.updatedAt", "sub_beaches"."ronin.updatedBy", "including_visitors"."id" as "visitors[0].id", "including_visitors"."ronin.locked" as "visitors[0].ronin.locked", "including_visitors"."ronin.createdAt" as "visitors[0].ronin.createdAt", "including_visitors"."ronin.createdBy" as "visitors[0].ronin.createdBy", "including_visitors"."ronin.updatedAt" as "visitors[0].ronin.updatedAt", "including_visitors"."ronin.updatedBy" as "visitors[0].ronin.updatedBy", "including_ronin_root"."id" as "visitors[0].id", "including_ronin_root"."ronin.locked" as "visitors[0].ronin.locked", "including_ronin_root"."ronin.createdAt" as "visitors[0].ronin.createdAt", "including_ronin_root"."ronin.createdBy" as "visitors[0].ronin.createdBy", "including_ronin_root"."ronin.updatedAt" as "visitors[0].ronin.updatedAt", "including_ronin_root"."ronin.updatedBy" as "visitors[0].ronin.updatedBy", "including_ronin_root"."handle" as "visitors[0].handle", "including_ronin_root"."firstName" as "visitors[0].firstName" FROM (SELECT * FROM "beaches" LIMIT 1) as sub_beaches LEFT JOIN "ronin_link_beach_visitors" as including_visitors ON ("including_visitors"."source" = "sub_beaches"."id") LEFT JOIN "accounts" as including_ronin_root ON ("including_ronin_root"."id" = "including_visitors"."target")`,
       params: [],
       returning: true,
     },
@@ -545,8 +545,6 @@ test('get single record including child records (one-to-many, defined manually)'
     },
     visitors: new Array(2).fill({
       id: expect.stringMatching(RECORD_ID_REGEX),
-      source: expect.stringMatching(RECORD_ID_REGEX),
-      target: expect.stringMatching(RECORD_ID_REGEX),
       ronin: {
         locked: false,
         createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),


### PR DESCRIPTION
This ensures that one-to-many relationships do not return unnecessary columns when they are resolved.