### PR TITLE
Export more query types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -436,6 +436,9 @@ export type {
   CountQuery,
   CountInstructions,
   CountInstructions as CountQueryInstructions,
+  CreateQuery,
+  AlterQuery,
+  DropQuery,
   // Query Instructions
   WithInstruction,
   CombinedInstructions,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -116,12 +116,12 @@ export type Instructions =
   | RemoveInstructions
   | CountInstructions;
 
-type CreateQuery = {
+export type CreateQuery = {
   model: string | PublicModel;
   to?: PublicModel;
 };
 
-type AlterQuery = {
+export type AlterQuery = {
   model: string;
   to?: Partial<PublicModel>;
   create?: {
@@ -150,7 +150,7 @@ type AlterQuery = {
   drop?: Partial<Record<ModelEntityEnum, string>>;
 };
 
-type DropQuery = {
+export type DropQuery = {
   model: string;
 };
 


### PR DESCRIPTION
This change exports the TypeScript types for the query types `create`, `alter`, and `drop`.