### PR TITLE
Allow for providing "many" relations while creating records

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,14 +92,12 @@ class Transaction {
       );
 
       // Every query can only produce one main statement (which can return output), but
-      // multiple dependency statements (which must be executed before the main one, but
-      // cannot return output themselves).
+      // multiple dependency statements (which must be executed either before or after
+      // the main one, but cannot return output themselves).
       //
-      // The order is essential, since the dependency statements are expected to not
-      // produce any output, so they should be executed first. The main statements, on the
-      // other hand, are expected to produce output, and that output should be a 1:1 match
-      // between RONIN queries and SQL statements, meaning one RONIN query should produce
-      // one main SQL statement.
+      // The main statements, unlike the dependency statements, are expected to produce
+      // output, and that output should be a 1:1 match between RONIN queries and SQL
+      // statements, meaning one RONIN query should produce one main SQL statement.
       const preDependencies = dependencies.filter(({ after }) => !after);
       const postDependencies = dependencies
         .map(({ after, ...rest }) => (after ? rest : null))

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -133,7 +133,7 @@ export const handleTo = (
         subQueryType: 'add' | 'remove',
         value?: unknown,
       ): Statement => {
-        const source = queryType === 'add' ? { id: toInstruction.id } : withInstruction;
+        const source = queryType === 'add' ? toInstruction : withInstruction;
         const recordDetails: Record<string, unknown> = { source };
 
         if (value) recordDetails.target = value;

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -154,13 +154,16 @@ export const handleTo = (
           { returning: false },
         ).main;
 
-        const details: InternalDependencyStatement = { ...query };
-
-        if (queryType === 'add' && subQueryType === 'add') {
-          details.after = true;
-        }
-
-        dependencyStatements.push(details);
+        // We are passing `after: true` here to ensure that the dependency statement is
+        // executed after the main statement. This is necessary because, in the case that
+        // the main statement creates a record, the record must of course first be
+        // created before it can be referenced from the associative table.
+        //
+        // We could first check if the main query and dependency query are both of type
+        // `add` and only then add the `after: true` property, but that would mean the
+        // list of generated dependency statements differs depending what kind of action
+        // is being performed, and that seems less clear in the output of the compiler.
+        dependencyStatements.push({ ...query, after: true });
       };
 
       if (Array.isArray(fieldValue)) {

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -163,6 +163,10 @@ export const handleTo = (
         // `add` and only then add the `after: true` property, but that would mean the
         // list of generated dependency statements differs depending what kind of action
         // is being performed, and that seems less clear in the output of the compiler.
+        //
+        // It seems clearer and more predictable to ensure that the dependency statements
+        // required for interacting with associative tables are always executed after the
+        // main statement, regardless of the type of action being performed.
         dependencyStatements.push({ ...query, after: true });
       };
 

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -160,7 +160,10 @@ export const handleTo = (
       };
 
       if (Array.isArray(fieldValue)) {
-        composeStatement('remove');
+        // If a record is being updated, clear all existing records of the associative
+        // model before inserting the new ones, to ensure that only the new ones are
+        // present and no old ones remain.
+        if (queryType === 'set') composeStatement('remove');
 
         for (const record of fieldValue) {
           composeStatement('add', record);

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -152,7 +152,7 @@ export const handleTo = (
 
         const details: Statement = { ...query };
 
-        if (subQueryType === 'add') {
+        if (queryType === 'add' && subQueryType === 'add') {
           details.after = true;
         }
 

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -4,7 +4,11 @@ import {
   getModelBySlug,
 } from '@/src/model';
 import type { Model } from '@/src/types/model';
-import type { FieldValue, SetInstructions, Statement } from '@/src/types/query';
+import type {
+  FieldValue,
+  InternalDependencyStatement,
+  SetInstructions,
+} from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
   flatten,
@@ -36,7 +40,7 @@ export const handleTo = (
   model: Model,
   statementParams: Array<unknown> | null,
   queryType: 'add' | 'set',
-  dependencyStatements: Array<Statement>,
+  dependencyStatements: Array<InternalDependencyStatement>,
   instructions: {
     with: NonNullable<SetInstructions['with']> | undefined;
     to: NonNullable<SetInstructions['to']>;
@@ -150,7 +154,7 @@ export const handleTo = (
           { returning: false },
         ).main;
 
-        const details: Statement = { ...query };
+        const details: InternalDependencyStatement = { ...query };
 
         if (queryType === 'add' && subQueryType === 'add') {
           details.after = true;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -16,11 +16,11 @@ import type {
   PublicModel,
 } from '@/src/types/model';
 import type {
+  InternalDependencyStatement,
   ModelEntityType,
   ModelQueryType,
   Query,
   QueryInstructionType,
-  Statement,
 } from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
@@ -481,7 +481,7 @@ const formatModelEntity = (
  */
 const handleSystemModel = (
   models: Array<Model>,
-  dependencyStatements: Array<Statement>,
+  dependencyStatements: Array<InternalDependencyStatement>,
   action: 'create' | 'alter' | 'drop',
   systemModel: PartialModel,
   newModel?: PartialModel,
@@ -517,7 +517,7 @@ const handleSystemModel = (
  */
 const handleSystemModels = (
   models: Array<Model>,
-  dependencyStatements: Array<Statement>,
+  dependencyStatements: Array<InternalDependencyStatement>,
   previousModel: Model,
   newModel: Model,
 ): void => {
@@ -603,7 +603,7 @@ const handleSystemModels = (
  */
 export const transformMetaQuery = (
   models: Array<Model>,
-  dependencyStatements: Array<Statement>,
+  dependencyStatements: Array<InternalDependencyStatement>,
   statementParams: Array<unknown> | null,
   query: Query,
 ): Query | null => {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -216,3 +216,11 @@ export interface InternalStatement extends Statement {
   query: Query;
   selectedFields: Array<InternalModelField>;
 }
+
+export interface InternalDependencyStatement extends Statement {
+  /**
+   * By default, the dependency statement is run before the main statement. By setting
+   * `after` to `true`, the dependency statement is run after the main statement instead.
+   */
+  after?: boolean;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ import { handleTo } from '@/src/instructions/to';
 import { handleWith } from '@/src/instructions/with';
 import { getModelBySlug, transformMetaQuery } from '@/src/model';
 import type { InternalModelField, Model } from '@/src/types/model';
-import type { Query, Statement } from '@/src/types/query';
+import type { InternalDependencyStatement, Query, Statement } from '@/src/types/query';
 import { RoninError, isObject, splitQuery } from '@/src/utils/helpers';
 import { formatIdentifiers } from '@/src/utils/statement';
 
@@ -45,7 +45,7 @@ export const compileQueryInput = (
     expandColumns?: boolean;
   },
 ): {
-  dependencies: Array<Statement>;
+  dependencies: Array<InternalDependencyStatement>;
   main: Statement;
   selectedFields: Array<InternalModelField>;
 } => {
@@ -53,7 +53,7 @@ export const compileQueryInput = (
   // statement. Their output is not relevant for the main statement, as they are merely
   // used to update the database in a way that is required for the main read statement
   // to return the expected results.
-  const dependencyStatements: Array<Statement> = [];
+  const dependencyStatements: Array<InternalDependencyStatement> = [];
 
   // If the query is a meta query of type `create`, `alter`, or `drop`, we need to
   // transform it into a regular query before it can be processed further.

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -269,17 +269,18 @@ test('add single record with many-cardinality link field (add)', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1)',
-      params: ['acc_39h8fhe98hefah8j'],
+      statement:
+        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1))',
+      params: ['markus'],
     },
     {
       statement:
-        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['acc_39h8fhe98hefah8j', 'david'],
+        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['markus', 'david'],
     },
     {
-      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("id" = ?1) RETURNING *`,
-      params: ['acc_39h8fhe98hefah8j'],
+      statement: `INSERT INTO "accounts" ("handle") VALUES (?1) RETURNING *`,
+      params: ['markus'],
       returning: true,
     },
   ]);

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -329,6 +329,11 @@ test('set single record to new many-cardinality link field', async () => {
 
   expect(transaction.statements).toEqual([
     {
+      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
+      params: ['elaine'],
+      returning: true,
+    },
+    {
       statement:
         'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1))',
       params: ['elaine'],
@@ -337,11 +342,6 @@ test('set single record to new many-cardinality link field', async () => {
       statement:
         'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
       params: ['elaine', 'david'],
-    },
-    {
-      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
-      params: ['elaine'],
-      returning: true,
     },
   ]);
 
@@ -392,14 +392,14 @@ test('set single record to new many-cardinality link field (add)', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['elaine', 'david'],
-    },
-    {
       statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
       params: ['elaine'],
       returning: true,
+    },
+    {
+      statement:
+        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['elaine', 'david'],
     },
   ]);
 
@@ -450,14 +450,14 @@ test('set single record to new many-cardinality link field (remove)', async () =
 
   expect(transaction.statements).toEqual([
     {
-      statement:
-        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1) AND "target" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['elaine', 'david'],
-    },
-    {
       statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
       params: ['elaine'],
       returning: true,
+    },
+    {
+      statement:
+        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1) AND "target" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['elaine', 'david'],
     },
   ]);
 

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -275,11 +275,6 @@ test('add single record with many-cardinality link field (add)', async () => {
     },
     {
       statement:
-        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1))',
-      params: ['markus'],
-    },
-    {
-      statement:
         'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
       params: ['markus', 'david'],
     },

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -297,7 +297,7 @@ test('set single record to new many-cardinality link field', async () => {
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8j',
+            handle: 'elaine',
           },
           to: {
             followers: [{ handle: 'david' }],
@@ -329,17 +329,18 @@ test('set single record to new many-cardinality link field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1)',
-      params: ['acc_39h8fhe98hefah8j'],
+      statement:
+        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1))',
+      params: ['elaine'],
     },
     {
       statement:
-        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['acc_39h8fhe98hefah8j', 'david'],
+        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['elaine', 'david'],
     },
     {
-      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("id" = ?1) RETURNING *`,
-      params: ['acc_39h8fhe98hefah8j'],
+      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
+      params: ['elaine'],
       returning: true,
     },
   ]);
@@ -357,7 +358,7 @@ test('set single record to new many-cardinality link field (add)', async () => {
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8j',
+            handle: 'elaine',
           },
           to: {
             followers: {
@@ -392,12 +393,12 @@ test('set single record to new many-cardinality link field (add)', async () => {
   expect(transaction.statements).toEqual([
     {
       statement:
-        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES (?1, (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['acc_39h8fhe98hefah8j', 'david'],
+        'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['elaine', 'david'],
     },
     {
-      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("id" = ?1) RETURNING *`,
-      params: ['acc_39h8fhe98hefah8j'],
+      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
+      params: ['elaine'],
       returning: true,
     },
   ]);
@@ -415,7 +416,7 @@ test('set single record to new many-cardinality link field (remove)', async () =
       set: {
         account: {
           with: {
-            id: 'acc_39h8fhe98hefah8j',
+            handle: 'elaine',
           },
           to: {
             followers: {
@@ -450,12 +451,12 @@ test('set single record to new many-cardinality link field (remove)', async () =
   expect(transaction.statements).toEqual([
     {
       statement:
-        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = ?1 AND "target" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
-      params: ['acc_39h8fhe98hefah8j', 'david'],
+        'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1) AND "target" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
+      params: ['elaine', 'david'],
     },
     {
-      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("id" = ?1) RETURNING *`,
-      params: ['acc_39h8fhe98hefah8j'],
+      statement: `UPDATE "accounts" SET "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("handle" = ?1) RETURNING *`,
+      params: ['elaine'],
       returning: true,
     },
   ]);

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -288,6 +288,10 @@ test('add single record with many-cardinality link field (add)', async () => {
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
+  expect(result.record).toMatchObject({
+    handle: 'markus',
+  });
+
   expect(result.record?.followers).toBeUndefined();
   expect(result.record?.ronin.updatedAt).toMatch(RECORD_TIMESTAMP_REGEX);
 });

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -269,6 +269,11 @@ test('add single record with many-cardinality link field (add)', async () => {
 
   expect(transaction.statements).toEqual([
     {
+      statement: `INSERT INTO "accounts" ("handle") VALUES (?1) RETURNING *`,
+      params: ['markus'],
+      returning: true,
+    },
+    {
       statement:
         'DELETE FROM "ronin_link_account_followers" WHERE ("source" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1))',
       params: ['markus'],
@@ -277,11 +282,6 @@ test('add single record with many-cardinality link field (add)', async () => {
       statement:
         'INSERT INTO "ronin_link_account_followers" ("source", "target") VALUES ((SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1), (SELECT "id" FROM "accounts" WHERE ("handle" = ?2) LIMIT 1))',
       params: ['markus', 'david'],
-    },
-    {
-      statement: `INSERT INTO "accounts" ("handle") VALUES (?1) RETURNING *`,
-      params: ['markus'],
-      returning: true,
     },
   ]);
 


### PR DESCRIPTION
Previously, it has already been possible to update existing records and:

- Add another record to a "many"-cardinality link field
- Remove a record from a "many"-cardinality link field
- Overwrite the current list of records in a "many"-cardinality link field with new ones

However, creating entirely new records and, at the same time, defining the list of records in a "many"-cardinality link field on that record has not yet been supported so far.

As of the current change, this is now possible:

```typescript
add.account.to({
  handle: 'elaine',
  followers: [{ handle: 'david' }]
});
```

Note that neither the `followers.containing` (adding records) nor the `followers.notContaining` (removing records) instructions are supported for `add` queries, since neither of them would make sense in that case.