### PR TITLE
Export record type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,10 @@ import type {
 import type { InternalStatement, Query, Statement } from '@/src/types/query';
 import type {
   MultipleRecordResult,
-  NativeRecord,
   ObjectRow,
   RawRow,
   Result,
+  ResultRecord,
 } from '@/src/types/result';
 import { compileQueryInput } from '@/src/utils';
 import { getProperty, omit, setProperty, splitQuery } from '@/src/utils/helpers';
@@ -122,26 +122,26 @@ class Transaction {
     return statements;
   };
 
-  #formatRows<Record = NativeRecord>(
+  #formatRows<Record = ResultRecord>(
     fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: true,
     isMeta: boolean,
   ): Record;
-  #formatRows<Record = NativeRecord>(
+  #formatRows<Record = ResultRecord>(
     fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: false,
     isMeta: boolean,
   ): Array<Record>;
 
-  #formatRows<Record = NativeRecord>(
+  #formatRows<Record = ResultRecord>(
     fields: Array<InternalModelField>,
     rows: Array<RawRow>,
     single: boolean,
     isMeta: boolean,
   ): Record | Array<Record> {
-    const records: Array<NativeRecord> = [];
+    const records: Array<ResultRecord> = [];
 
     for (const row of rows) {
       const record = fields.reduce((acc, field, fieldIndex) => {
@@ -222,7 +222,7 @@ class Transaction {
 
         setProperty(acc, newSlug, newValue);
         return acc;
-      }, {} as NativeRecord);
+      }, {} as ResultRecord);
 
       const existingRecord = record.id
         ? records.find((existingRecord) => {
@@ -247,8 +247,8 @@ class Transaction {
       }, new Set<string>());
 
       for (const arrayField of joinFields.values()) {
-        const currentValue = existingRecord[arrayField] as Array<NativeRecord>;
-        const newValue = record[arrayField] as Array<NativeRecord>;
+        const currentValue = existingRecord[arrayField] as Array<ResultRecord>;
+        const newValue = record[arrayField] as Array<ResultRecord>;
 
         for (const newRecord of newValue) {
           if ('id' in newRecord) {
@@ -372,7 +372,7 @@ class Transaction {
             const direction = queryInstructions?.before ? 'moreBefore' : 'moreAfter';
             const lastRecord = output.records.at(
               direction === 'moreAfter' ? -1 : 0,
-            ) as NativeRecord;
+            ) as ResultRecord;
 
             output[direction] = generatePaginationCursor(
               model,
@@ -387,7 +387,7 @@ class Transaction {
             const direction = queryInstructions?.before ? 'moreAfter' : 'moreBefore';
             const firstRecord = output.records.at(
               direction === 'moreAfter' ? -1 : 0,
-            ) as NativeRecord;
+            ) as ResultRecord;
 
             output[direction] = generatePaginationCursor(
               model,
@@ -451,7 +451,7 @@ export type {
 } from '@/src/types/query';
 
 // Expose result types
-export type { Result } from '@/src/types/result';
+export type { Result, ResultRecord } from '@/src/types/result';
 
 // Strip any properties from the root model that are internal
 const CLEAN_ROOT_MODEL = omit(ROOT_MODEL, ['system']) as PublicModel;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -5,7 +5,7 @@ export type ObjectRow = Record<string, unknown>;
 
 export type Row = RawRow | ObjectRow;
 
-export type NativeRecord = Record<string, unknown> & {
+export type ResultRecord = Record<string, unknown> & {
   id: string;
   ronin: {
     locked: boolean;
@@ -16,13 +16,13 @@ export type NativeRecord = Record<string, unknown> & {
   };
 };
 
-export type SingleRecordResult<T = NativeRecord> = {
+export type SingleRecordResult<T = ResultRecord> = {
   record: T | null;
 
   modelFields: Record<ModelField['slug'], ModelField['type']>;
 };
 
-export type MultipleRecordResult<T = NativeRecord> = {
+export type MultipleRecordResult<T = ResultRecord> = {
   records: Array<T>;
   moreAfter?: string;
   moreBefore?: string;
@@ -34,7 +34,7 @@ export type AmountResult = {
   amount: number;
 };
 
-export type Result<T = NativeRecord> =
+export type Result<T = ResultRecord> =
   | SingleRecordResult<T>
   | MultipleRecordResult<T>
   | AmountResult;

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,7 +1,7 @@
 import { getFieldFromModel } from '@/src/model';
 import type { Model } from '@/src/types/model';
 import type { GetInstructions } from '@/src/types/query';
-import type { NativeRecord } from '@/src/types/result';
+import type { ResultRecord } from '@/src/types/result';
 import { getProperty } from '@/src/utils/helpers';
 
 // The separator and NULL placeholder have to be somewhat unique so that they don't
@@ -21,7 +21,7 @@ export const CURSOR_NULL_PLACEHOLDER = 'RONIN_NULL';
 export const generatePaginationCursor = (
   model: Model,
   orderedBy: GetInstructions['orderedBy'],
-  record: NativeRecord,
+  record: ResultRecord,
 ): string => {
   const { ascending = [], descending = [] } = orderedBy || {};
   const keys = [...ascending, ...descending];

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -7,8 +7,8 @@ import {
 import { type Model, type Query, Transaction } from '@/src/index';
 import type {
   AmountResult,
-  NativeRecord,
   Result,
+  ResultRecord,
   SingleRecordResult,
 } from '@/src/types/result';
 
@@ -170,7 +170,7 @@ test('pass multiple record queries at once', async () => {
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const results = transaction.formatResults(rawResults) as Array<
-    Result<Partial<NativeRecord>>
+    Result<Partial<ResultRecord>>
   >;
 
   // Assert whether the results are provided in the same order as the original queries.


### PR DESCRIPTION
This change exports a `ResultRecord` type from the compiler, which defines a record stored in a RONIN database.