### PR TITLE
Always return correct `count` query results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,9 +303,16 @@ class Transaction {
     const normalizedResults: Array<Array<RawRow>> = raw
       ? (results as Array<Array<RawRow>>)
       : results.map((rows) => {
-          return rows.map((row) => {
+          return rows.map((row, index) => {
+            const { query } = this.#internalStatements[index];
+
+            // If the row is already an array, return it as-is.
             if (Array.isArray(row)) return row;
-            if (row['COUNT(*)']) return [row['COUNT(*)']];
+
+            // If the row is the result of a `count` query, return its amount result.
+            if (query.count) return [row.amount];
+
+            // If the row is an object, return its values as an array.
             return Object.values(row);
           });
         });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -103,7 +103,7 @@ test('count multiple records', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT COUNT(*) FROM "accounts"`,
+      statement: `SELECT (COUNT(*)) as "amount" FROM "accounts"`,
       params: [],
       returning: true,
     },
@@ -152,7 +152,7 @@ test('pass multiple record queries at once', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT COUNT(*) FROM "accounts"',
+      statement: 'SELECT (COUNT(*)) as "amount" FROM "accounts"',
       params: [],
       returning: true,
     },


### PR DESCRIPTION
Previously, if the option `expandColumns: true` was passed to the compiler, [this error](https://discord.com/channels/1099977902629589095/1331647781558947942/1331786460009070602) reported by a customer on Discord was happening.

With the current change, the error no longer happens and the results for `count` queries are always returned reliably.