### PR TITLE
Explicitly select all columns by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,26 +127,7 @@ new Transaction(queries, {
   // Instead of returning an array of parameters for every statement (which allows for
   // preventing SQL injections), all parameters are inlined directly into the SQL strings.
   // This option should only be used if the generated SQL will be manually verified.
-  inlineParams: true,
-
-  // By default, in the generated SQL statements, the compiler does not alias columns if
-  // multiple different tables with the same column names are being joined. Only the table
-  // names themselves are aliased.
-  //
-  // This ensures the cleanest possible SQL statements in conjunction with the default
-  // behavior of SQL databases, where the result of a statement is a list (array) of
-  // values, which are inherently not prone to conflicts.
-  //
-  // If the driver being used instead returns an object for every row, the driver must
-  // ensure the uniqueness of every key in that object, which means prefixing duplicated
-  // column names with the name of the respective table, if multiple tables are joined
-  // (example for an object key: "table_name.column_name").
-  //
-  // Drivers that return objects for rows offer this behavior as an option that is
-  // usually called "expand columns". If the driver being used does not offer such an
-  // option, you can instead activate the option in the compiler, which results in longer
-  // SQL statements because all column names are aliased.
-  expandColumns: true
+  inlineParams: true
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,6 @@ interface TransactionOptions {
    * separating them out into a dedicated `params` array.
    */
   inlineParams?: boolean;
-  /** Alias column names that are duplicated when joining multiple tables. */
-  expandColumns?: boolean;
 }
 
 class Transaction {
@@ -88,7 +86,6 @@ class Transaction {
         query,
         modelsWithPresets,
         options?.inlineParams ? null : [],
-        { expandColumns: options?.expandColumns },
       );
 
       // Every query can only produce one main statement (which can return output), but

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -116,7 +116,6 @@ export const compileQueryInput = (
       selecting: instructions?.selecting,
       including: instructions?.including,
     },
-    options,
   );
 
   let statement = '';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,8 +47,6 @@ export const compileQueryInput = (
      * the parent model in the nested query (the current query).
      */
     parentModel?: Model;
-    /** Alias column names that are duplicated when joining multiple tables. */
-    expandColumns?: boolean;
   },
 ): {
   dependencies: Array<InternalDependencyStatement>;

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -33,7 +33,7 @@ test('get multiple records before cursor', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "beaches" WHERE (("ronin.createdAt" > '2024-12-08T10:47:58.079Z')) ORDER BY "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" WHERE (("ronin.createdAt" > '2024-12-08T10:47:58.079Z')) ORDER BY "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
@@ -105,7 +105,7 @@ test('get multiple records before cursor ordered by string field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "beaches" WHERE ((IFNULL("name", -1e999) < ?1 COLLATE NOCASE) OR ("name" = ?1 AND ("ronin.createdAt" > '2024-12-10T10:47:58.079Z'))) ORDER BY "name" COLLATE NOCASE ASC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" WHERE ((IFNULL("name", -1e999) < ?1 COLLATE NOCASE) OR ("name" = ?1 AND ("ronin.createdAt" > '2024-12-10T10:47:58.079Z'))) ORDER BY "name" COLLATE NOCASE ASC, "ronin.createdAt" DESC LIMIT 3`,
       params: ['Manly'],
       returning: true,
     },
@@ -180,7 +180,7 @@ test('get multiple records before cursor ordered by boolean field', async () => 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "members" WHERE ((IFNULL("pending", -1e999) < ?1) OR ("pending" = ?1 AND ("ronin.createdAt" > '2024-10-09T10:47:58.079Z'))) ORDER BY "pending" ASC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "pending" FROM "members" WHERE ((IFNULL("pending", -1e999) < ?1) OR ("pending" = ?1 AND ("ronin.createdAt" > '2024-10-09T10:47:58.079Z'))) ORDER BY "pending" ASC, "ronin.createdAt" DESC LIMIT 3`,
       params: [1],
       returning: true,
     },
@@ -259,7 +259,7 @@ test('get multiple records before cursor ordered by number field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "products" WHERE (("position" > ?1) OR ("position" = ?1 AND ("ronin.createdAt" > '2024-12-11T10:47:58.079Z'))) ORDER BY "position" DESC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "position", "name" FROM "products" WHERE (("position" > ?1) OR ("position" = ?1 AND ("ronin.createdAt" > '2024-12-11T10:47:58.079Z'))) ORDER BY "position" DESC, "ronin.createdAt" DESC LIMIT 3`,
       params: [1],
       returning: true,
     },
@@ -340,7 +340,7 @@ test('get multiple records before cursor ordered by empty string field', async (
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "beaches" WHERE (("sandColor" IS NOT NULL) OR ("sandColor" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "sandColor" COLLATE NOCASE DESC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "sandColor" FROM "beaches" WHERE (("sandColor" IS NOT NULL) OR ("sandColor" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "sandColor" COLLATE NOCASE DESC, "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
@@ -420,7 +420,7 @@ test('get multiple records before cursor ordered by empty boolean field', async 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "beaches" WHERE (("swimmingAllowed" IS NOT NULL) OR ("swimmingAllowed" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "swimmingAllowed" DESC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "swimmingAllowed" FROM "beaches" WHERE (("swimmingAllowed" IS NOT NULL) OR ("swimmingAllowed" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "swimmingAllowed" DESC, "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
@@ -501,7 +501,7 @@ test('get multiple records before cursor ordered by empty number field', async (
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "beaches" WHERE (("rating" IS NOT NULL) OR ("rating" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "rating" DESC, "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "rating" FROM "beaches" WHERE (("rating" IS NOT NULL) OR ("rating" IS NULL AND ("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "rating" DESC, "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },
@@ -579,7 +579,7 @@ test('get multiple records before cursor while filtering', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "products" WHERE (("name" IS NOT NULL) AND (("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "ronin.createdAt" DESC LIMIT 3`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "products" WHERE (("name" IS NOT NULL) AND (("ronin.createdAt" > '2024-12-08T10:47:58.079Z'))) ORDER BY "ronin.createdAt" DESC LIMIT 3`,
       params: [],
       returning: true,
     },

--- a/tests/instructions/for.test.ts
+++ b/tests/instructions/for.test.ts
@@ -52,7 +52,8 @@ test('get single record for preset', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "members" WHERE ("account" = ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account" FROM "members" WHERE ("account" = ?1) LIMIT 1',
       params: ['acc_39h8fhe98hefah9j'],
       returning: true,
     },
@@ -156,7 +157,7 @@ test('get single record for preset containing field with condition', async () =>
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "team" FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
       params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
@@ -259,7 +260,7 @@ test('get single record for preset containing field without condition', async ()
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "team" FROM "products" WHERE ("team" = (SELECT "team" FROM "members" WHERE ("account" = ?1) ORDER BY "activeAt" DESC LIMIT 1)) LIMIT 1',
       params: ['acc_39h8fhe98hefah8j'],
       returning: true,
     },
@@ -334,7 +335,8 @@ test('get single record for preset on existing object instruction', async () => 
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "members" WHERE ("team" = ?1 AND "account" = ?2) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account", "team" FROM "members" WHERE ("team" = ?1 AND "account" = ?2) LIMIT 1',
       params: ['tea_39h8fhe98hefah9j', 'acc_39h8fhe98hefah8j'],
       returning: true,
     },
@@ -455,7 +457,7 @@ test('get single record including parent record (many-to-one)', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT "members"."id", "members"."ronin.locked", "members"."ronin.createdAt", "members"."ronin.createdBy", "members"."ronin.updatedAt", "members"."ronin.updatedBy", "members"."account", "including_account"."id" as "account.id", "including_account"."ronin.locked" as "account.ronin.locked", "including_account"."ronin.createdAt" as "account.ronin.createdAt", "including_account"."ronin.createdBy" as "account.ronin.createdBy", "including_account"."ronin.updatedAt" as "account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },
@@ -774,7 +776,7 @@ test('get single record including child records (one-to-many, defined automatica
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "sub_accounts"."id") WHERE ("sub_accounts"."handle" = ?1)`,
+      statement: `SELECT "sub_accounts"."id", "sub_accounts"."ronin.locked", "sub_accounts"."ronin.createdAt", "sub_accounts"."ronin.createdBy", "sub_accounts"."ronin.updatedAt", "sub_accounts"."ronin.updatedBy", "sub_accounts"."handle", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account" FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "sub_accounts"."id") WHERE ("sub_accounts"."handle" = ?1)`,
       params: ['elaine'],
       returning: true,
     },

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -41,7 +41,7 @@ test('get single record including unrelated record without filter', async () => 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "products" CROSS JOIN (SELECT * FROM "teams" LIMIT 1) as "including_team" LIMIT 1`,
+      statement: `SELECT "products"."id", "products"."ronin.locked", "products"."ronin.createdAt", "products"."ronin.createdBy", "products"."ronin.updatedAt", "products"."ronin.updatedBy", "including_team"."id" as "team.id", "including_team"."ronin.locked" as "team.ronin.locked", "including_team"."ronin.createdAt" as "team.ronin.createdAt", "including_team"."ronin.createdBy" as "team.ronin.createdBy", "including_team"."ronin.updatedAt" as "team.ronin.updatedAt", "including_team"."ronin.updatedBy" as "team.ronin.updatedBy" FROM "products" CROSS JOIN (SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "teams" LIMIT 1) as "including_team" LIMIT 1`,
       params: [],
       returning: true,
     },
@@ -116,7 +116,7 @@ test('get single record including unrelated record with filter', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = "members"."account") LIMIT 1`,
+      statement: `SELECT "members"."id", "members"."ronin.locked", "members"."ronin.createdAt", "members"."ronin.createdBy", "members"."ronin.updatedAt", "members"."ronin.updatedBy", "members"."account", "including_account"."id" as "account.id", "including_account"."ronin.locked" as "account.ronin.locked", "including_account"."ronin.createdAt" as "account.ronin.createdAt", "including_account"."ronin.createdBy" as "account.ronin.createdBy", "including_account"."ronin.updatedAt" as "account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = "members"."account") LIMIT 1`,
       params: [],
       returning: true,
     },

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -189,7 +189,7 @@ test('get single record including unrelated record that is not found', async () 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = ?1) LIMIT 1`,
+      statement: `SELECT "members"."id", "members"."ronin.locked", "members"."ronin.createdAt", "members"."ronin.createdBy", "members"."ronin.updatedAt", "members"."ronin.updatedBy", "members"."account", "including_account"."id" as "account.id", "including_account"."ronin.locked" as "account.ronin.locked", "including_account"."ronin.createdAt" as "account.ronin.createdAt", "including_account"."ronin.createdBy" as "account.ronin.createdBy", "including_account"."ronin.updatedAt" as "account.ronin.updatedAt", "including_account"."ronin.updatedBy" as "account.ronin.updatedBy" FROM "members" LEFT JOIN "accounts" as "including_account" ON ("including_account"."id" = ?1) LIMIT 1`,
       params: ['1234'],
       returning: true,
     },
@@ -330,7 +330,7 @@ test('get single record including unrelated records without filter', async () =>
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "products" LIMIT 1) as sub_products CROSS JOIN "beaches" as "including_beaches[0]"`,
+      statement: `SELECT "sub_products"."id", "sub_products"."ronin.locked", "sub_products"."ronin.createdAt", "sub_products"."ronin.createdBy", "sub_products"."ronin.updatedAt", "sub_products"."ronin.updatedBy", "sub_products"."name", "including_beaches[0]"."id" as "beaches[0].id", "including_beaches[0]"."ronin.locked" as "beaches[0].ronin.locked", "including_beaches[0]"."ronin.createdAt" as "beaches[0].ronin.createdAt", "including_beaches[0]"."ronin.createdBy" as "beaches[0].ronin.createdBy", "including_beaches[0]"."ronin.updatedAt" as "beaches[0].ronin.updatedAt", "including_beaches[0]"."ronin.updatedBy" as "beaches[0].ronin.updatedBy", "including_beaches[0]"."name" as "beaches[0].name" FROM (SELECT * FROM "products" LIMIT 1) as sub_products CROSS JOIN "beaches" as "including_beaches[0]"`,
       params: [],
       returning: true,
     },
@@ -407,7 +407,7 @@ test('get single record including unrelated records with filter', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "sub_accounts"."id")`,
+      statement: `SELECT "sub_accounts"."id", "sub_accounts"."ronin.locked", "sub_accounts"."ronin.createdAt", "sub_accounts"."ronin.createdBy", "sub_accounts"."ronin.updatedAt", "sub_accounts"."ronin.updatedBy", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account" FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "sub_accounts"."id")`,
       params: [],
       returning: true,
     },
@@ -494,7 +494,7 @@ test('get single record including unrelated records that are not found', async (
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = ?1)`,
+      statement: `SELECT "sub_accounts"."id", "sub_accounts"."ronin.locked", "sub_accounts"."ronin.createdAt", "sub_accounts"."ronin.createdBy", "sub_accounts"."ronin.updatedAt", "sub_accounts"."ronin.updatedBy", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account" FROM (SELECT * FROM "accounts" LIMIT 1) as sub_accounts LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = ?1)`,
       params: ['1234'],
       returning: true,
     },
@@ -560,7 +560,7 @@ test('get multiple records including unrelated records with filter', async () =>
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id")`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account" FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id")`,
       params: [],
       returning: true,
     },
@@ -659,7 +659,7 @@ test('get multiple records including unrelated records that are not found', asyn
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = ?1)`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account" FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = ?1)`,
       params: ['1234'],
       returning: true,
     },
@@ -749,7 +749,7 @@ test('get multiple records including unrelated records with filter (hoisted)', a
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" LEFT JOIN "members" as "including_ronin_root" ON ("including_ronin_root"."account" = "accounts"."id")`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "accounts"."handle", "including_ronin_root"."id", "including_ronin_root"."ronin.locked", "including_ronin_root"."ronin.createdAt", "including_ronin_root"."ronin.createdBy", "including_ronin_root"."ronin.updatedAt", "including_ronin_root"."ronin.updatedBy", "including_ronin_root"."account", "including_ronin_root"."team" FROM "accounts" LEFT JOIN "members" as "including_ronin_root" ON ("including_ronin_root"."account" = "accounts"."id")`,
       params: [],
       returning: true,
     },
@@ -859,7 +859,7 @@ test('get multiple records including unrelated records with filter (nested)', as
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id") LEFT JOIN "teams" as "including_members[0].team" ON ("including_members[0].team"."id" = "including_members[0]"."team")`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "accounts"."handle", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account", "including_members[0]"."team" as "members[0].team", "including_members[0].team"."id" as "members[0].team.id", "including_members[0].team"."ronin.locked" as "members[0].team.ronin.locked", "including_members[0].team"."ronin.createdAt" as "members[0].team.ronin.createdAt", "including_members[0].team"."ronin.createdBy" as "members[0].team.ronin.createdBy", "including_members[0].team"."ronin.updatedAt" as "members[0].team.ronin.updatedAt", "including_members[0].team"."ronin.updatedBy" as "members[0].team.ronin.updatedBy", "including_members[0].team"."locations" as "members[0].team.locations" FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id") LEFT JOIN "teams" as "including_members[0].team" ON ("including_members[0].team"."id" = "including_members[0]"."team")`,
       params: [],
       returning: true,
     },
@@ -1055,7 +1055,7 @@ test('get multiple records including unrelated records with filter (nested, hois
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id") LEFT JOIN "teams" as "including_members[0]{1}" ON ("including_members[0]{1}"."id" = "including_members[0]"."team")`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "accounts"."handle", "including_members[0]"."id" as "members[0].id", "including_members[0]"."ronin.locked" as "members[0].ronin.locked", "including_members[0]"."ronin.createdAt" as "members[0].ronin.createdAt", "including_members[0]"."ronin.createdBy" as "members[0].ronin.createdBy", "including_members[0]"."ronin.updatedAt" as "members[0].ronin.updatedAt", "including_members[0]"."ronin.updatedBy" as "members[0].ronin.updatedBy", "including_members[0]"."account" as "members[0].account", "including_members[0]"."team" as "members[0].team", "including_members[0]{1}"."id" as "members[0]{1}.id", "including_members[0]{1}"."ronin.locked" as "members[0]{1}.ronin.locked", "including_members[0]{1}"."ronin.createdAt" as "members[0]{1}.ronin.createdAt", "including_members[0]{1}"."ronin.createdBy" as "members[0]{1}.ronin.createdBy", "including_members[0]{1}"."ronin.updatedAt" as "members[0]{1}.ronin.updatedAt", "including_members[0]{1}"."ronin.updatedBy" as "members[0]{1}.ronin.updatedBy", "including_members[0]{1}"."locations" as "members[0]{1}.locations" FROM "accounts" LEFT JOIN "members" as "including_members[0]" ON ("including_members[0]"."account" = "accounts"."id") LEFT JOIN "teams" as "including_members[0]{1}" ON ("including_members[0]{1}"."id" = "including_members[0]"."team")`,
       params: [],
       returning: true,
     },
@@ -1194,7 +1194,7 @@ test('get single record including unrelated ordered record', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "products" CROSS JOIN (SELECT * FROM "beaches" ORDER BY "name" COLLATE NOCASE DESC LIMIT 1) as "including_beach" LIMIT 1`,
+      statement: `SELECT "products"."id", "products"."ronin.locked", "products"."ronin.createdAt", "products"."ronin.createdBy", "products"."ronin.updatedAt", "products"."ronin.updatedBy", "products"."name", "including_beach"."id" as "beach.id", "including_beach"."ronin.locked" as "beach.ronin.locked", "including_beach"."ronin.createdAt" as "beach.ronin.createdAt", "including_beach"."ronin.createdBy" as "beach.ronin.createdBy", "including_beach"."ronin.updatedAt" as "beach.ronin.updatedAt", "including_beach"."ronin.updatedBy" as "beach.ronin.updatedBy", "including_beach"."name" as "beach.name" FROM "products" CROSS JOIN (SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" ORDER BY "name" COLLATE NOCASE DESC LIMIT 1) as "including_beach" LIMIT 1`,
       params: [],
       returning: true,
     },
@@ -1275,7 +1275,7 @@ test('get single record including unrelated ordered records', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM (SELECT * FROM "products" LIMIT 1) as sub_products CROSS JOIN (SELECT * FROM "beaches" ORDER BY "name" COLLATE NOCASE DESC) as "including_beaches[0]"`,
+      statement: `SELECT "sub_products"."id", "sub_products"."ronin.locked", "sub_products"."ronin.createdAt", "sub_products"."ronin.createdBy", "sub_products"."ronin.updatedAt", "sub_products"."ronin.updatedBy", "sub_products"."name", "including_beaches[0]"."id" as "beaches[0].id", "including_beaches[0]"."ronin.locked" as "beaches[0].ronin.locked", "including_beaches[0]"."ronin.createdAt" as "beaches[0].ronin.createdAt", "including_beaches[0]"."ronin.createdBy" as "beaches[0].ronin.createdBy", "including_beaches[0]"."ronin.updatedAt" as "beaches[0].ronin.updatedAt", "including_beaches[0]"."ronin.updatedBy" as "beaches[0].ronin.updatedBy", "including_beaches[0]"."name" as "beaches[0].name" FROM (SELECT * FROM "products" LIMIT 1) as sub_products CROSS JOIN (SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name" FROM "beaches" ORDER BY "name" COLLATE NOCASE DESC) as "including_beaches[0]"`,
       params: [],
       returning: true,
     },
@@ -1366,7 +1366,7 @@ test('get single record including ephemeral field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ?1 as "companyName" FROM "teams" LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", ?1 as "companyName" FROM "teams" LIMIT 1`,
       params: ['Example Company'],
       returning: true,
     },
@@ -1428,7 +1428,7 @@ test('get single record including ephemeral field containing expression', async 
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ("firstName" || ' ' || "lastName") as "fullName" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "firstName", "lastName", "handle", ("firstName" || ' ' || "lastName") as "fullName" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1`,
       params: ['elaine'],
       returning: true,
     },
@@ -1478,7 +1478,7 @@ test('get single record including deeply nested ephemeral field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT *, ?1 as "sand.quality" FROM "beaches" LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", ?1 as "sand.quality" FROM "beaches" LIMIT 1`,
       params: ['extraordinary'],
       returning: true,
     },

--- a/tests/instructions/limited-to.test.ts
+++ b/tests/instructions/limited-to.test.ts
@@ -24,7 +24,8 @@ test('get multiple records limited to amount', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "beaches" ORDER BY "ronin.createdAt" DESC LIMIT 3',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "beaches" ORDER BY "ronin.createdAt" DESC LIMIT 3',
       params: [],
       returning: true,
     },
@@ -73,7 +74,7 @@ test('get multiple records limited to amount ordered by link field', async () =>
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "members" ORDER BY "account" DESC, "ronin.createdAt" DESC LIMIT 3',
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account" FROM "members" ORDER BY "account" DESC, "ronin.createdAt" DESC LIMIT 3',
       params: [],
       returning: true,
     },

--- a/tests/instructions/ordered-by.test.ts
+++ b/tests/instructions/ordered-by.test.ts
@@ -33,7 +33,7 @@ test('get multiple records ordered by field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC`,
       params: [],
       returning: true,
     },
@@ -89,7 +89,7 @@ test('get multiple records ordered by expression', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY ("firstName" || ' ' || "lastName") ASC`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "firstName", "lastName" FROM "accounts" ORDER BY ("firstName" || ' ' || "lastName") ASC`,
       params: [],
       returning: true,
     },
@@ -143,7 +143,7 @@ test('get multiple records ordered by multiple fields', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC, "lastName" COLLATE NOCASE ASC`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "lastName" FROM "accounts" ORDER BY "handle" COLLATE NOCASE ASC, "lastName" COLLATE NOCASE ASC`,
       params: [],
       returning: true,
     },

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -896,7 +896,8 @@ test('add multiple records with nested sub query', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'INSERT INTO "users" SELECT * FROM "accounts" RETURNING *',
+      statement:
+        'INSERT INTO "users" SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" RETURNING *',
       params: [],
       returning: true,
     },
@@ -973,7 +974,7 @@ test('add multiple records with nested sub query including additional fields', a
   expect(transaction.statements).toEqual([
     {
       statement:
-        'INSERT INTO "users" SELECT *, ?1 as "nonExistingField" FROM "accounts" RETURNING *',
+        'INSERT INTO "users" SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", ?1 as "nonExistingField" FROM "accounts" RETURNING *',
       params: ['Custom Field Value'],
       returning: true,
     },

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -34,7 +34,8 @@ test('get single record with field being value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" = ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1',
       params: ['elaine'],
       returning: true,
     },
@@ -77,7 +78,8 @@ test('get single record with field not being value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" != ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" != ?1) LIMIT 1',
       params: ['elaine'],
       returning: true,
     },
@@ -120,7 +122,8 @@ test('get single record with field not being empty', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" IS NOT NULL) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" IS NOT NULL) LIMIT 1',
       params: [],
       returning: true,
     },
@@ -163,7 +166,8 @@ test('get single record with field starting with value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
       params: ['el%'],
       returning: true,
     },
@@ -206,7 +210,8 @@ test('get single record with field not starting with value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
       params: ['el%'],
       returning: true,
     },
@@ -249,7 +254,8 @@ test('get single record with field ending with value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
       params: ['%ne'],
       returning: true,
     },
@@ -292,7 +298,8 @@ test('get single record with field not ending with value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
       params: ['%ne'],
       returning: true,
     },
@@ -335,7 +342,8 @@ test('get single record with field containing value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" LIKE ?1) LIMIT 1',
       params: ['%ain%'],
       returning: true,
     },
@@ -378,7 +386,8 @@ test('get single record with field not containing value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" NOT LIKE ?1) LIMIT 1',
       params: ['%ain%'],
       returning: true,
     },
@@ -421,7 +430,8 @@ test('get single record with field greater than value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "products" WHERE ("position" > ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "position" FROM "products" WHERE ("position" > ?1) LIMIT 1',
       params: [1],
       returning: true,
     },
@@ -464,7 +474,8 @@ test('get single record with field greater or equal to value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "products" WHERE ("position" >= ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "position" FROM "products" WHERE ("position" >= ?1) LIMIT 1',
       params: [2],
       returning: true,
     },
@@ -507,7 +518,8 @@ test('get single record with field less than value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "products" WHERE ("position" < ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "position" FROM "products" WHERE ("position" < ?1) LIMIT 1',
       params: [3],
       returning: true,
     },
@@ -550,7 +562,8 @@ test('get single record with field less or equal to value', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "products" WHERE ("position" <= ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "position" FROM "products" WHERE ("position" <= ?1) LIMIT 1',
       params: [3],
       returning: true,
     },
@@ -601,7 +614,7 @@ test('get single record with multiple fields being value', async () => {
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "accounts" WHERE ("handle" = ?1 AND "firstName" = ?2) LIMIT 1',
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "firstName" FROM "accounts" WHERE ("handle" = ?1 AND "firstName" = ?2) LIMIT 1',
       params: ['elaine', 'Elaine'],
       returning: true,
     },
@@ -656,7 +669,7 @@ test('get single record with link field', async () => {
   expect(transaction.statements).toEqual([
     {
       statement:
-        'SELECT * FROM "members" WHERE ("account" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1)) LIMIT 1',
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account" FROM "members" WHERE ("account" = (SELECT "id" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1)) LIMIT 1',
       params: ['elaine'],
       returning: true,
     },
@@ -714,7 +727,8 @@ test('get single record with link field and id', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "members" WHERE ("account" = ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account" FROM "members" WHERE ("account" = ?1) LIMIT 1',
       params: ['acc_39h8fhe98hefah9j'],
       returning: true,
     },
@@ -763,7 +777,8 @@ test('get single record with link field and id with condition', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "members" WHERE ("account" = ?1) LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "account" FROM "members" WHERE ("account" = ?1) LIMIT 1',
       params: ['acc_39h8fhe98hefah9j'],
       returning: true,
     },
@@ -806,7 +821,7 @@ test('get single record with json field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "teams" WHERE (json_extract(locations, '$.europe') = ?1) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "locations" FROM "teams" WHERE (json_extract(locations, '$.europe') = ?1) LIMIT 1`,
       params: ['berlin'],
       returning: true,
     },
@@ -851,7 +866,7 @@ test('get single record with blob field', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE (json_extract(avatar, '$.meta.type') = ?1) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "avatar" FROM "accounts" WHERE (json_extract(avatar, '$.meta.type') = ?1) LIMIT 1`,
       params: ['image/png'],
       returning: true,
     },
@@ -901,7 +916,7 @@ test('get single record with one of fields', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE ("handle" = ?1 OR "firstName" = ?2) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "firstName" FROM "accounts" WHERE ("handle" = ?1 OR "firstName" = ?2) LIMIT 1`,
       params: ['elaine', 'David'],
       returning: true,
     },
@@ -951,7 +966,7 @@ test('get single record with one of field conditions', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE ("handle" = ?1 OR "handle" = ?2) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" = ?1 OR "handle" = ?2) LIMIT 1`,
       params: ['elaine', 'david'],
       returning: true,
     },
@@ -994,7 +1009,7 @@ test('get single record with one of field values', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE ("handle" = ?1 OR "handle" = ?2) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" = ?1 OR "handle" = ?2) LIMIT 1`,
       params: ['elaine', 'david'],
       returning: true,
     },
@@ -1037,7 +1052,7 @@ test('get single record with one of nested field values', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "teams" WHERE ("billing.currency" = ?1 OR "billing.currency" = ?2) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "billing.currency" FROM "teams" WHERE ("billing.currency" = ?1 OR "billing.currency" = ?2) LIMIT 1`,
       params: ['EUR', 'USD'],
       returning: true,
     },
@@ -1086,7 +1101,7 @@ test('get single record with name identifier', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE ("firstName" = ?1) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "firstName" FROM "accounts" WHERE ("firstName" = ?1) LIMIT 1`,
       params: ['Elaine'],
       returning: true,
     },
@@ -1132,7 +1147,7 @@ test('get single record with slug identifier', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT * FROM "accounts" WHERE ("handle" = ?1) LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" WHERE ("handle" = ?1) LIMIT 1`,
       params: ['elaine'],
       returning: true,
     },

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -288,7 +288,8 @@ test('get existing models', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "ronin_schema"',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets" FROM "ronin_schema"',
       params: [],
       returning: true,
     },
@@ -543,7 +544,7 @@ test('query a model that was just created', () => {
   expect(transaction.statements.map(({ statement }) => statement)).toEqual([
     `CREATE TABLE "accounts" ("id" TEXT PRIMARY KEY DEFAULT ('acc_' || lower(substr(hex(randomblob(12)), 1, 16))), "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.updatedBy" TEXT)`,
     'INSERT INTO "ronin_schema" ("slug", "id", "pluralSlug", "name", "pluralName", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields") VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) RETURNING *',
-    'SELECT * FROM "accounts" LIMIT 1',
+    'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "accounts" LIMIT 1',
     'DROP TABLE "accounts"',
     'DELETE FROM "ronin_schema" WHERE ("slug" = ?1) RETURNING *',
   ]);
@@ -579,7 +580,7 @@ test('query a model that was just updated', () => {
   expect(transaction.statements.map(({ statement }) => statement)).toEqual([
     'ALTER TABLE "accounts" RENAME TO "users"',
     `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE ("slug" = ?7) RETURNING *`,
-    'SELECT * FROM "users" LIMIT 1',
+    'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "users" LIMIT 1',
   ]);
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -31,7 +31,8 @@ test('get single record', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: 'SELECT * FROM "accounts" LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "accounts" LIMIT 1',
       params: [],
       returning: true,
     },
@@ -162,7 +163,8 @@ test('pass multiple record queries at once', async () => {
       returning: true,
     },
     {
-      statement: 'SELECT * FROM "accounts" LIMIT 1',
+      statement:
+        'SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle" FROM "accounts" LIMIT 1',
       params: [],
       returning: true,
     },


### PR DESCRIPTION
With this change, all columns will now be selected by default, without requiring the `expandColumns` option.

As a result, the SQL statements of all tests are now much more detailed, but we will also be able to remove the Wasm driver from the engine.