### PR TITLE
Ensure hoisting joined records works correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ executed and their results can be formatted by the compiler as well:
 
 ```typescript
 // Passing `rawResults` (rows being arrays of values) provided by the database (ideal)
-const results: Array<Result> = transaction.formatResults(rawResults);
+const results: Array<Result> = transaction.formatResults(rawResults, true);
 
 // Passing `objectResults` (rows being objects) provided by a driver
 const results: Array<Result> = transaction.formatResults(objectResults, false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,10 +299,10 @@ class Transaction {
     // format expected by developers.
     const normalizedResults: Array<Array<RawRow>> = raw
       ? (results as Array<Array<RawRow>>)
-      : results.map((rows) => {
-          return rows.map((row, index) => {
-            const { query } = this.#internalStatements[index];
+      : results.map((rows, index) => {
+          const { query } = this.#internalStatements[index];
 
+          return rows.map((row) => {
             // If the row is already an array, return it as-is.
             if (Array.isArray(row)) return row;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,7 @@ class Transaction {
    */
   formatResults<Record>(
     results: Array<Array<RawRow>> | Array<Array<ObjectRow>>,
-    raw = true,
+    raw = false,
   ): Array<Result<Record>> {
     // If the provided results are raw (rows being arrays of values, which is the most
     // ideal format in terms of performance, since the driver doesn't need to format

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,9 +278,9 @@ class Transaction {
    *
    * @param results - A list of results from the database, where each result is an array
    * of rows.
-   * @param raw - By default, rows are expected to be arrays of values, which is how SQL
-   * databases return rows by default. If the driver being used returns rows as objects
-   * instead, this option should be set to `false`.
+   * @param raw - By default, rows are expected to be objects. If the driver being used
+   * returns rows as arrays of values (which is how SQL databases return rows directly),
+   * this option should be set to `true`.
    *
    * @returns A list of formatted RONIN results, where each result is either a single
    * RONIN record, an array of RONIN records, or a RONIN count result.

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -60,11 +60,13 @@ export const handleIncluding = (
 
     const subSingle = queryModel !== relatedModel.pluralSlug;
 
-    const { tableAlias, subMountingPath } = composeMountingPath(
+    const subMountingPath = composeMountingPath(
       subSingle,
       ephemeralFieldSlug,
       options.mountingPath,
     );
+
+    const tableAlias = `including_${subMountingPath}`;
 
     // If no `with` query instruction is provided, we want to perform a CROSS JOIN
     // instead of a LEFT JOIN, because it is guaranteed that the joined rows are the same

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -56,7 +56,7 @@ export const handleSelecting = (
     .map((field) => {
       const newField: InternalModelField = { ...field, mountingPath: field.slug };
 
-      if (options.mountingPath) {
+      if (options.mountingPath && options.mountingPath !== 'ronin_root') {
         // Remove all occurrences of `{n}`, which are used to indicate the index of a join
         // that is being performed on the same nesting level of a record. Meaning if, for
         // example, multiple different tables are being joined and their outputs must all

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -114,16 +114,12 @@ export const handleSelecting = (
         if (!model.tableAlias)
           model.tableAlias = single && !subSingle ? `sub_${model.table}` : model.table;
 
-        const { tableAlias, subMountingPath } = composeMountingPath(
-          subSingle,
-          key,
-          options.mountingPath,
-        );
+        const subMountingPath = composeMountingPath(subSingle, key, options.mountingPath);
 
         const { columns: nestedColumns, selectedFields: nestedSelectedFields } =
           handleSelecting(
             models,
-            { ...subQueryModel, tableAlias },
+            { ...subQueryModel, tableAlias: `including_${subMountingPath}` },
             statementParams,
             subSingle,
             {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -71,20 +71,17 @@ export const composeMountingPath = (
   single: boolean,
   key: string,
   mountingPath?: string,
-): { subMountingPath: string; tableAlias: string } => {
-  const subMountingPath =
-    key === 'ronin_root'
-      ? mountingPath
-        ? mountingPath.replace(
-            MOUNTING_PATH_SUFFIX,
-            (_, p, __, n) => `${p}{${n ? +n + 1 : 1}}`,
-          )
-        : key
-      : `${mountingPath ? `${mountingPath}.` : ''}${single ? key : `${key}[0]`}`;
+): string => {
+  if (key === 'ronin_root') {
+    return mountingPath
+      ? mountingPath.replace(
+          MOUNTING_PATH_SUFFIX,
+          (_, p, __, n) => `${p}{${n ? +n + 1 : 1}}`,
+        )
+      : key;
+  }
 
-  const tableAlias = `including_${subMountingPath}`;
-
-  return { subMountingPath, tableAlias };
+  return `${mountingPath ? `${mountingPath}.` : ''}${single ? key : `${key}[0]`}`;
 };
 
 type RoninErrorCode =

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -71,7 +71,7 @@ export const composeMountingPath = (
   single: boolean,
   key: string,
   mountingPath?: string,
-): { subMountingPath?: string; tableAlias: string } => {
+): { subMountingPath: string; tableAlias: string } => {
   const subMountingPath =
     key === 'ronin_root'
       ? mountingPath
@@ -79,10 +79,10 @@ export const composeMountingPath = (
             MOUNTING_PATH_SUFFIX,
             (_, p, __, n) => `${p}{${n ? +n + 1 : 1}}`,
           )
-        : undefined
+        : key
       : `${mountingPath ? `${mountingPath}.` : ''}${single ? key : `${key}[0]`}`;
 
-  const tableAlias = `including_${subMountingPath || key}`;
+  const tableAlias = `including_${subMountingPath}`;
 
   return { subMountingPath, tableAlias };
 };

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -749,7 +749,7 @@ test('get multiple records including unrelated records with filter (hoisted)', a
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "accounts"."handle", "including_ronin_root"."id", "including_ronin_root"."ronin.locked", "including_ronin_root"."ronin.createdAt", "including_ronin_root"."ronin.createdBy", "including_ronin_root"."ronin.updatedAt", "including_ronin_root"."ronin.updatedBy", "including_ronin_root"."account", "including_ronin_root"."team" FROM "accounts" LEFT JOIN "members" as "including_ronin_root" ON ("including_ronin_root"."account" = "accounts"."id")`,
+      statement: `SELECT "accounts"."id", "accounts"."ronin.locked", "accounts"."ronin.createdAt", "accounts"."ronin.createdBy", "accounts"."ronin.updatedAt", "accounts"."ronin.updatedBy", "accounts"."handle", "including_ronin_root"."id" as "ronin_root.id", "including_ronin_root"."ronin.locked" as "ronin_root.ronin.locked", "including_ronin_root"."ronin.createdAt" as "ronin_root.ronin.createdAt", "including_ronin_root"."ronin.createdBy" as "ronin_root.ronin.createdBy", "including_ronin_root"."ronin.updatedAt" as "ronin_root.ronin.updatedAt", "including_ronin_root"."ronin.updatedBy" as "ronin_root.ronin.updatedBy", "including_ronin_root"."account" as "ronin_root.account", "including_ronin_root"."team" as "ronin_root.team" FROM "accounts" LEFT JOIN "members" as "including_ronin_root" ON ("including_ronin_root"."account" = "accounts"."id")`,
       params: [],
       returning: true,
     },

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -216,16 +216,12 @@ test('set single record to new one-cardinality link field', async () => {
     },
   ]);
 
-  const [[targetRecord]] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [[targetRecord]] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
@@ -668,16 +664,12 @@ test('set single record to new nested link field', async () => {
     },
   ]);
 
-  const [[targetRecord]] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [[targetRecord]] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
@@ -793,16 +785,12 @@ test('set single record to result of nested query', async () => {
     },
   ]);
 
-  const [[targetRecord]] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT lastName FROM "accounts" WHERE ("handle" = 'david') LIMIT 1`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [[targetRecord]] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT lastName FROM "accounts" WHERE ("handle" = 'david') LIMIT 1`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
@@ -903,17 +891,13 @@ test('add multiple records with nested sub query', async () => {
     },
   ]);
 
-  const [targetRecords] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts"`,
-        params: [],
-      },
-      ...transaction.statements,
-    ],
-    false,
-  );
+  const [targetRecords] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts"`,
+      params: [],
+    },
+    ...transaction.statements,
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;
@@ -1044,16 +1028,12 @@ test('add multiple records with nested sub query and specific fields', async () 
     },
   ]);
 
-  const [targetRecords] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts"`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [targetRecords] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts"`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;
@@ -1102,16 +1082,12 @@ test('add multiple records with nested sub query and specific meta fields', asyn
     },
   ]);
 
-  const [targetRecords] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts"`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [targetRecords] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts"`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -675,16 +675,12 @@ test('get single record with link field', async () => {
     },
   ]);
 
-  const [[targetRecord]] = await queryEphemeralDatabase(
-    models,
-    [
-      {
-        statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
-        params: [],
-      },
-    ],
-    false,
-  );
+  const [[targetRecord]] = await queryEphemeralDatabase(models, [
+    {
+      statement: `SELECT * FROM "accounts" WHERE ("handle" = 'elaine') LIMIT 1`,
+      params: [],
+    },
+  ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;


### PR DESCRIPTION
This change resolves a bug that was causing joined records that were being "hoisted upwards" (as shown in [this test](https://github.com/ronin-co/compiler/blob/40e16e490ac99b9230a2da03197eae91f4560e9d/tests/instructions/including.test.ts#L700)) to not be formatted correctly.

In addition, the performance of the test suite is being improved dramatically by removing the Wasm SQLite driver.