### PR TITLE
Ensure lowercase ID prefixes by default

### DIFF
--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -91,7 +91,7 @@ const modelAttributes: Array<
   ['pluralSlug', 'slug', pluralize],
   ['name', 'slug', slugToName],
   ['pluralName', 'pluralSlug', slugToName],
-  ['idPrefix', 'slug', (slug: string) => slug.slice(0, 3)],
+  ['idPrefix', 'slug', (slug: string) => slug.slice(0, 3).toLowerCase()],
   ['table', 'pluralSlug', convertToSnakeCase],
 ];
 

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -207,6 +207,22 @@ test('create new model with suitable default identifiers', () => {
   expect(transaction.statements[1].params[9]).toEqual('handle');
 });
 
+test('create new model with lowercased id prefix', () => {
+  const queries: Array<Query> = [
+    {
+      create: {
+        model: { slug: 'myPaintings' },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements[1].params[5]).toBe('myp');
+});
+
 // Assert whether the system models associated with the model are correctly created.
 test('create new model that has system models associated with it', () => {
   const fields: Model['fields'] = [


### PR DESCRIPTION
This change ensures that the `idPrefix` attribute that is added to every model is always lowercase by default.