### PR TITLE
Gracefully handle undefined pagination cursor

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -240,7 +240,8 @@ export const compileQueryInput = (
 
   if (
     instructions &&
-    (Object.hasOwn(instructions, 'before') || Object.hasOwn(instructions, 'after'))
+    (typeof instructions.before !== 'undefined' ||
+      typeof instructions.after !== 'undefined')
   ) {
     if (single) {
       throw new RoninError({


### PR DESCRIPTION
This change ensures that the compiler doesn't throw an error if the `before` or `after` instructions contain `undefined` as their value, as such a value must be supported for the purpose of composition:

```typescript
const loadComments = (after?: string) => {
  return get.comments({
    with: {
      post: postId,
    },
    limitedTo: 5,
    after,
  });
};
 ```

This also makes it possible to revert https://github.com/AndyBitz/site/pull/37.