### PR TITLE
Avoid repeating default fields and presets

### DIFF
--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -187,7 +187,11 @@ export const addDefaultModelFields = (model: Model, isNew: boolean): Model => {
   // If the model is being newly created or if new fields were provided for an existing
   // model, we would like to attach the system fields to the model.
   if (isNew || newFields.length > 0) {
-    copiedModel.fields = [...getSystemFields(copiedModel.idPrefix), ...newFields];
+    const additionalFields = getSystemFields(copiedModel.idPrefix).filter((field) => {
+      return !newFields.some((newField) => newField.slug === field.slug);
+    });
+
+    copiedModel.fields = [...additionalFields, ...newFields];
   }
 
   return copiedModel as Model;

--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -340,8 +340,15 @@ export const addDefaultModelPresets = (list: Array<Model>, model: Model): Model 
     });
   }
 
-  if (Object.keys(defaultPresets).length > 0) {
-    model.presets = [...defaultPresets, ...(model.presets || [])];
+  if (defaultPresets.length > 0) {
+    const existingPresets = model.presets || [];
+    const additionalPresets = defaultPresets.filter((preset) => {
+      return !existingPresets.some(
+        (existingPreset) => existingPreset.slug === preset.slug,
+      );
+    });
+
+    model.presets = [...additionalPresets, ...existingPresets];
   }
 
   return model;

--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -182,16 +182,17 @@ export const addDefaultModelAttributes = (model: PartialModel, isNew: boolean): 
  */
 export const addDefaultModelFields = (model: Model, isNew: boolean): Model => {
   const copiedModel = { ...model };
-  const newFields = copiedModel.fields || [];
+  const existingFields = copiedModel.fields || [];
 
   // If the model is being newly created or if new fields were provided for an existing
   // model, we would like to attach the system fields to the model.
-  if (isNew || newFields.length > 0) {
-    const additionalFields = getSystemFields(copiedModel.idPrefix).filter((field) => {
-      return !newFields.some((newField) => newField.slug === field.slug);
+  if (isNew || existingFields.length > 0) {
+    // Only add default fields that are not already present in the model.
+    const additionalFields = getSystemFields(copiedModel.idPrefix).filter((newField) => {
+      return !existingFields.some(({ slug }) => slug === newField.slug);
     });
 
-    copiedModel.fields = [...additionalFields, ...newFields];
+    copiedModel.fields = [...additionalFields, ...existingFields];
   }
 
   return copiedModel as Model;
@@ -342,10 +343,10 @@ export const addDefaultModelPresets = (list: Array<Model>, model: Model): Model 
 
   if (defaultPresets.length > 0) {
     const existingPresets = model.presets || [];
-    const additionalPresets = defaultPresets.filter((preset) => {
-      return !existingPresets.some(
-        (existingPreset) => existingPreset.slug === preset.slug,
-      );
+
+    // Only add default presets that are not already present in the model.
+    const additionalPresets = defaultPresets.filter((newPreset) => {
+      return !existingPresets.some(({ slug }) => slug === newPreset.slug);
     });
 
     model.presets = [...additionalPresets, ...existingPresets];

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -107,6 +107,7 @@ test('inline statement parameters containing serialized expression', async () =>
   });
 });
 
+// Ensure that default fields are not repeated if they are already present.
 test('provide models containing default fields', async () => {
   const queries: Array<Query> = [
     {
@@ -154,6 +155,7 @@ test('provide models containing default fields', async () => {
   });
 });
 
+// Ensure that default presets are not repeated if they are already present.
 test('provide models containing default presets', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
This change ensures that the compiler can receive models that already include default fields and presets.

Instead of attaching the default fields and presets again to those models, it now checks if they already exist and doesn't set them if they are already present.