### PR TITLE
Support `with` instruction for `add` queries

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -145,8 +145,7 @@ export const handleTo = (
         const query = compileQueryInput(
           {
             [subQueryType]: {
-              [associativeModelSlug]:
-                subQueryType === 'add' ? { to: recordDetails } : { with: recordDetails },
+              [associativeModelSlug]: { with: recordDetails },
             },
           },
           models,

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -740,7 +740,7 @@ export const transformMetaQuery = (
         Object.defineProperty(modelWithObjects, entity, { value: entities[entity] });
       }
 
-      queryTypeDetails = { to: modelWithObjects };
+      queryTypeDetails = { with: modelWithObjects };
 
       // Add any system models that might be needed by the model.
       getSystemModels(models, modelWithPresets).map((systemModel) => {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -111,7 +111,7 @@ export type SetQuery = Record<
 >;
 export type AddQuery = Record<
   string,
-  Omit<CombinedInstructions, 'with' | 'using'> & { to: FieldSelector }
+  Omit<CombinedInstructions, 'with' | 'using'> & { with: FieldSelector }
 >;
 export type RemoveQuery = Record<string, Omit<CombinedInstructions, 'to'>>;
 export type CountQuery = Record<string, Omit<CombinedInstructions, 'to'> | null>;

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -146,12 +146,12 @@ test('set single record with empty `to` instruction', () => {
   expect(error).toHaveProperty('code', 'INVALID_TO_VALUE');
 });
 
-test('add single record with empty `to` instruction', () => {
+test('add single record with empty `with` instruction', () => {
   const queries: Array<Query> = [
     {
       add: {
         account: {
-          to: {},
+          with: {},
         },
       },
     },
@@ -174,9 +174,9 @@ test('add single record with empty `to` instruction', () => {
   expect(error).toBeInstanceOf(RoninError);
   expect(error).toHaveProperty(
     'message',
-    'When using a `add` query, the `to` instruction must be a non-empty object.',
+    'When using a `add` query, the `with` instruction must be a non-empty object.',
   );
-  expect(error).toHaveProperty('code', 'INVALID_TO_VALUE');
+  expect(error).toHaveProperty('code', 'INVALID_WITH_VALUE');
 });
 
 test('get single record with `before` instruction', () => {

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -55,7 +55,7 @@ const prefillDatabase = async (
       });
 
       return formattedData.map((row): Query => {
-        return { add: { [createdModel.slug]: { to: row } } };
+        return { add: { [createdModel.slug]: { with: row } } };
       });
     },
   );

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -234,7 +234,7 @@ test('add single record with many-cardinality link field (add)', async () => {
     {
       add: {
         account: {
-          to: {
+          with: {
             handle: 'markus',
             followers: [{ handle: 'david' }],
           },
@@ -847,7 +847,7 @@ test('add multiple records with nested sub query', async () => {
     {
       add: {
         users: {
-          to: {
+          with: {
             [QUERY_SYMBOLS.QUERY]: {
               get: {
                 accounts: null,
@@ -912,7 +912,7 @@ test('add multiple records with nested sub query including additional fields', a
     {
       add: {
         users: {
-          to: {
+          with: {
             [QUERY_SYMBOLS.QUERY]: {
               get: {
                 accounts: {
@@ -982,7 +982,7 @@ test('add multiple records with nested sub query and specific fields', async () 
     {
       add: {
         users: {
-          to: {
+          with: {
             [QUERY_SYMBOLS.QUERY]: {
               get: {
                 accounts: {
@@ -1048,7 +1048,7 @@ test('add multiple records with nested sub query and specific meta fields', asyn
     {
       add: {
         users: {
-          to: {
+          with: {
             [QUERY_SYMBOLS.QUERY]: {
               get: {
                 accounts: {
@@ -1108,7 +1108,7 @@ test('try to add multiple records with nested sub query including non-existent f
     {
       add: {
         newAccounts: {
-          to: {
+          with: {
             [QUERY_SYMBOLS.QUERY]: {
               get: {
                 oldAccounts: {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -63,7 +63,7 @@ test('create new model', () => {
         {
           add: {
             signup: {
-              to: {
+              with: {
                 year: 2000,
               },
             },
@@ -1282,7 +1282,7 @@ test('create new trigger for creating records', () => {
       {
         add: {
           signup: {
-            to: {
+            with: {
               year: 2000,
             },
           },
@@ -1335,7 +1335,7 @@ test('create new trigger for creating records with targeted fields', () => {
       {
         add: {
           signup: {
-            to: {
+            with: {
               year: 2000,
             },
           },
@@ -1394,7 +1394,7 @@ test('create new trigger for creating records with multiple effects', () => {
       {
         add: {
           signup: {
-            to: {
+            with: {
               year: 2000,
             },
           },
@@ -1403,7 +1403,7 @@ test('create new trigger for creating records with multiple effects', () => {
       {
         add: {
           candidate: {
-            to: {
+            with: {
               year: 2020,
             },
           },
@@ -1460,7 +1460,7 @@ test('create new per-record trigger for creating records', () => {
       {
         add: {
           member: {
-            to: {
+            with: {
               account: {
                 [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
               },
@@ -1593,7 +1593,7 @@ test('create new per-record trigger with filters for creating records', () => {
       {
         add: {
           member: {
-            to: {
+            with: {
               account: {
                 [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
               },
@@ -1677,7 +1677,7 @@ test('drop existing trigger', () => {
           action: 'INSERT',
           effects: [
             {
-              add: { member: { to: { account: 'test' } } },
+              add: { member: { with: { account: 'test' } } },
             },
           ],
         },
@@ -2003,7 +2003,7 @@ test('try to create new trigger with targeted fields and wrong action', () => {
     {
       add: {
         signup: {
-          to: {
+          with: {
             year: 2000,
           },
         },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -10,7 +10,7 @@ test('inline statement parameters', async () => {
     {
       add: {
         account: {
-          to: {
+          with: {
             handle: 'elaine',
             emails: ['test@site.co', 'elaine@site.com'],
           },


### PR DESCRIPTION
This change updates the syntax of `add` queries from this...

```typescript
add.account.to({
  name: 'Elaine',
  handle: 'elaine'
});
```

...to this:

```typescript
add.account.with({
  name: 'Elaine',
  handle: 'elaine'
});
```

Like this, the syntax is more cohesive.