### PR TITLE
Do not allow model entities upon altering

### DIFF
--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -138,7 +138,9 @@ export type CreateQuery = {
 
 export type AlterQuery = {
   model: string;
-  to?: Partial<Omit<PublicModel, 'fields' | 'indexes' | 'triggers' | 'presets' | 'idPrefix'>>;
+  to?: Partial<
+    Omit<PublicModel, 'fields' | 'indexes' | 'triggers' | 'presets' | 'idPrefix'>
+  >;
   create?: {
     field?: ModelField;
     index?: ModelIndex;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -138,7 +138,7 @@ export type CreateQuery = {
 
 export type AlterQuery = {
   model: string;
-  to?: Partial<PublicModel>;
+  to?: Partial<Omit<PublicModel, 'fields' | 'indexes' | 'triggers' | 'presets' | 'idPrefix'>>;
   create?: {
     field?: ModelField;
     index?: ModelIndex;


### PR DESCRIPTION
When altering models, it is not possible to pass any model entity (fields, indexes, triggers, or presets), as those must be altered individually. The change ensures that the types reflect this.

Furthermore, the `idPrefix` attribute can also only be provided when the model is created.