### PR TITLE
Ensure correct file name for instructions

### DIFF
--- a/src/instructions/using.ts
+++ b/src/instructions/using.ts
@@ -18,14 +18,14 @@ export const handleUsing = (
   // The `using` instruction might either contain an array of preset slugs, or an object
   // in which the keys are preset slugs and the values are arguments that should be
   // passed to the respective presets.
-  const normalizedFor = Array.isArray(instructions.using)
+  const normalizedUsing = Array.isArray(instructions.using)
     ? Object.fromEntries(instructions.using.map((presetSlug) => [presetSlug, null]))
     : instructions.using;
 
-  for (const presetSlug in normalizedFor) {
-    if (!Object.hasOwn(normalizedFor, presetSlug)) continue;
+  for (const presetSlug in normalizedUsing) {
+    if (!Object.hasOwn(normalizedUsing, presetSlug)) continue;
 
-    const arg = normalizedFor[presetSlug];
+    const arg = normalizedUsing[presetSlug];
     const preset = model.presets?.find((preset) => preset.slug === presetSlug);
 
     if (!preset) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,10 @@
 import { handleBeforeOrAfter } from '@/src/instructions/before-after';
-import { handleUsing } from '@/src/instructions/for';
 import { handleIncluding } from '@/src/instructions/including';
 import { handleLimitedTo } from '@/src/instructions/limited-to';
 import { handleOrderedBy } from '@/src/instructions/ordered-by';
 import { handleSelecting } from '@/src/instructions/selecting';
 import { handleTo } from '@/src/instructions/to';
+import { handleUsing } from '@/src/instructions/using';
 import { handleWith } from '@/src/instructions/with';
 import { getModelBySlug, transformMetaQuery } from '@/src/model';
 import type { InternalModelField, Model } from '@/src/types/model';


### PR DESCRIPTION
This applies an internal change that does not affect the behavior of the compiler.

The `for.ts` file in the `instructions` folder is now correctly named `using.ts`, just like its respective `using.test.ts` file.