### PR TITLE
Allow for including count of joined records

### DIFF
--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -53,6 +53,9 @@ export const handleIncluding = (
     const { queryType, queryModel, queryInstructions } = splitQuery(symbol.value);
     let modifiableQueryInstructions = queryInstructions;
 
+    // If the query is of type `count`, it was already added in `handleSelecting` instead.
+    if (queryType === 'count') continue;
+
     const relatedModel = getModelBySlug(models, queryModel);
 
     let joinType: 'LEFT' | 'CROSS' = 'LEFT';
@@ -104,6 +107,7 @@ export const handleIncluding = (
         },
         models,
         statementParams,
+        { parentModel: model },
       );
 
       relatedTableSelector = `(${subSelect.main.statement})`;

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -1,6 +1,7 @@
 import { getFieldFromModel, getModelBySlug } from '@/src/model';
 import type { InternalModelField, Model, ModelField } from '@/src/types/model';
 import type { Instructions } from '@/src/types/query';
+import { compileQueryInput } from '@/src/utils';
 import {
   QUERY_SYMBOLS,
   RAW_FIELD_TYPES,
@@ -95,8 +96,23 @@ export const handleSelecting = (
 
       // A JOIN is being performed.
       if (symbol?.type === 'query') {
-        const { queryModel, queryInstructions } = splitQuery(symbol.value);
+        const { queryType, queryModel, queryInstructions } = splitQuery(symbol.value);
         const subQueryModel = getModelBySlug(models, queryModel);
+
+        if (queryType === 'count') {
+          const subSelect = compileQueryInput(symbol.value, models, statementParams, {
+            parentModel: { ...model, tableAlias: model.table },
+          });
+
+          selectedFields.push({
+            slug: key,
+            mountingPath: key,
+            type: 'number',
+            mountedValue: `(${subSelect.main.statement})`,
+          });
+
+          continue;
+        }
 
         // If a sub query was found in the `including` instruction, that means different
         // tables will be joined later on during the compilation of the query.

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -99,6 +99,8 @@ export const handleSelecting = (
         const { queryType, queryModel, queryInstructions } = splitQuery(symbol.value);
         const subQueryModel = getModelBySlug(models, queryModel);
 
+        // If the query is of type `count`, generate a sub SQL statement for counting the
+        // records and add the result as a selected column to the main query.
         if (queryType === 'count') {
           const subSelect = compileQueryInput(symbol.value, models, statementParams, {
             parentModel: { ...model, tableAlias: model.table },

--- a/tests/instructions/including.test.ts
+++ b/tests/instructions/including.test.ts
@@ -516,6 +516,72 @@ test('get single record including unrelated records that are not found', async (
   });
 });
 
+test('get single record including count of unrelated records', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        account: {
+          including: {
+            memberAmount: {
+              [QUERY_SYMBOLS.QUERY]: {
+                count: {
+                  members: {
+                    with: {
+                      account: {
+                        [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT}id`,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'member',
+      fields: [
+        {
+          slug: 'account',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", (SELECT (COUNT(*)) as "amount" FROM "members" WHERE "account" = "accounts"."id") as "memberAmount" FROM "accounts" LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toEqual({
+    id: expect.stringMatching(RECORD_ID_REGEX),
+    ronin: {
+      locked: false,
+      createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      createdBy: null,
+      updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      updatedBy: null,
+    },
+    memberAmount: 2,
+  });
+});
+
 test('get multiple records including unrelated records with filter', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
The compiler currently already supports joining other records into the records that are being retrieved in the main query:

```typescript
get.accounts.including(f => ({
  members: get.members.with.account(f.id)
}));
```

With the current change, it now also becomes possible to join the count of records instead of the records themselves:

```typescript
get.accounts.including(f => ({
  memberAmount: count.members.with.account(f.id)
}));
```