### PR TITLE
Prevent actions for many-cardinality link fields

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -324,11 +324,19 @@ export const getSystemModels = (models: Array<Model>, model: Model): Array<Model
               slug: 'source',
               type: 'link',
               target: model.slug,
+              actions: {
+                onDelete: 'CASCADE',
+                onUpdate: 'CASCADE',
+              },
             },
             {
               slug: 'target',
               type: 'link',
               target: relatedModel.slug,
+              actions: {
+                onDelete: 'CASCADE',
+                onUpdate: 'CASCADE',
+              },
             },
           ],
         });

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -92,7 +92,7 @@ export type ModelField = ModelFieldBasics &
         /** The target model of the relationship that is being established. */
         target: string;
         /** Whether the field should be related to one record, or many records. */
-        kind?: 'one' | 'many';
+        kind?: 'one';
         /**
          * If the target record is updated or deleted, the defined actions maybe executed.
          */
@@ -100,6 +100,14 @@ export type ModelField = ModelFieldBasics &
           onDelete?: ModelFieldLinkAction;
           onUpdate?: ModelFieldLinkAction;
         };
+      }
+    | {
+        /** The kind of value that should be stored inside the field. */
+        type: 'link';
+        /** The target model of the relationship that is being established. */
+        target: string;
+        /** Whether the field should be related to one record, or many records. */
+        kind: 'many';
       }
   );
 

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -247,7 +247,7 @@ test('create new model that has system models associated with it', () => {
   const transaction = new Transaction(queries, { models });
 
   expect(transaction.statements[1]).toEqual({
-    statement: `CREATE TABLE "ronin_link_account_followers" ("id" TEXT PRIMARY KEY DEFAULT ('ron_' || lower(substr(hex(randomblob(12)), 1, 16))), "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.updatedBy" TEXT, "source" TEXT REFERENCES accounts("id"), "target" TEXT REFERENCES accounts("id"))`,
+    statement: `CREATE TABLE "ronin_link_account_followers" ("id" TEXT PRIMARY KEY DEFAULT ('ron_' || lower(substr(hex(randomblob(12)), 1, 16))), "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.updatedBy" TEXT, "source" TEXT REFERENCES accounts("id") ON DELETE CASCADE ON UPDATE CASCADE, "target" TEXT REFERENCES accounts("id") ON DELETE CASCADE ON UPDATE CASCADE)`,
     params: [],
   });
 });
@@ -750,7 +750,7 @@ test('create new field with many-cardinality relationship', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TABLE "ronin_link_account_followers" ("id" TEXT PRIMARY KEY DEFAULT ('ron_' || lower(substr(hex(randomblob(12)), 1, 16))), "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.updatedBy" TEXT, "source" TEXT REFERENCES accounts("id"), "target" TEXT REFERENCES accounts("id"))`,
+      statement: `CREATE TABLE "ronin_link_account_followers" ("id" TEXT PRIMARY KEY DEFAULT ('ron_' || lower(substr(hex(randomblob(12)), 1, 16))), "ronin.locked" BOOLEAN, "ronin.createdAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.createdBy" TEXT, "ronin.updatedAt" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'), "ronin.updatedBy" TEXT, "source" TEXT REFERENCES accounts("id") ON DELETE CASCADE ON UPDATE CASCADE, "target" TEXT REFERENCES accounts("id") ON DELETE CASCADE ON UPDATE CASCADE)`,
       params: [],
     },
     {


### PR DESCRIPTION
On RONIN, link field constraints are designed to prevent the existence of children that don't have parents, and link field actions exist to automatically handle the children if something happens to the parents.

It therefore doesn't make sense to offer link field actions for many-cardinality relationships, since, in those cases, parents are referencing children, and parents should never be affected if something happens to the children, since there can be many children and only one parent.

Lastly, if the parents disappear, their references to the children should also disappear.