### PR TITLE
Make it possible to run queries for all models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,8 @@ class Transaction {
 
     // Check if the list of queries contains any queries with the model `all`, as those
     // must be expanded into multiple queries.
-    const expandedQueries: Array<{ query: Query; expansionIndex?: number }> = queries.flatMap(
-      (query, expansionIndex) => {
+    const expandedQueries: Array<{ query: Query; expansionIndex?: number }> =
+      queries.flatMap((query, expansionIndex) => {
         const { queryType, queryModel, queryInstructions } = splitQuery(query);
 
         // If the model defined in the query is called `all`, that means we need to expand
@@ -102,8 +102,7 @@ class Transaction {
         }
 
         return { query };
-      },
-    );
+      });
 
     for (const { query, expansionIndex } of expandedQueries) {
       const { dependencies, main, selectedFields } = compileQueryInput(
@@ -356,7 +355,8 @@ class Transaction {
         ): Array<Result<RecordType>> => {
           if (typeof expansionIndex !== 'undefined') {
             if (!finalResults[expansionIndex]) finalResults[expansionIndex] = {};
-            (finalResults[expansionIndex] as ExpandedResult<RecordType>)[queryModel] = result;
+            (finalResults[expansionIndex] as ExpandedResult<RecordType>)[queryModel] =
+              result;
           } else {
             finalResults.push(result);
           }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -288,6 +288,12 @@ export const ROOT_MODEL: PartialModel = {
 };
 
 /**
+ * We're adding the attributes of the root model at bootup time, so that the performance
+ * of the query compilation is not affected.
+ */
+export const ROOT_MODEL_WITH_ATTRIBUTES = addDefaultModelAttributes(ROOT_MODEL, true);
+
+/**
  * Composes a list of potential system models that might be required for a manually
  * provided model.
  *

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -215,8 +215,15 @@ export interface Statement {
 }
 
 export interface InternalStatement extends Statement {
+  /** The RONIN query for which the SQL statement was generated. */
   query: Query;
+  /** The RONIN model fields that were selected for the SQL statement. */
   selectedFields: Array<InternalModelField>;
+  /**
+   * If the associated RONIN query was automatically generated because a different
+   * RONIN query was expanded, this contains the index of the original query.
+   */
+  queryIndex?: number;
 }
 
 export interface InternalDependencyStatement extends Statement {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -223,7 +223,7 @@ export interface InternalStatement extends Statement {
    * If the associated RONIN query was automatically generated because a different
    * RONIN query was expanded, this contains the index of the original query.
    */
-  queryIndex?: number;
+  expansionIndex?: number;
 }
 
 export interface InternalDependencyStatement extends Statement {

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,4 +1,4 @@
-import type { ModelField } from '@/src/types/model';
+import type { Model, ModelField } from '@/src/types/model';
 
 export type RawRow = Array<unknown>;
 export type ObjectRow = Record<string, unknown>;
@@ -34,7 +34,11 @@ export type AmountResult = {
   amount: number;
 };
 
-export type Result<T = ResultRecord> =
+export type RegularResult<T = ResultRecord> =
   | SingleRecordResult<T>
   | MultipleRecordResult<T>
   | AmountResult;
+
+export type ExpandedResult<T = ResultRecord> = Record<Model['slug'], RegularResult<T>>;
+
+export type Result<T = ResultRecord> = RegularResult<T> | ExpandedResult<T>;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -212,3 +212,42 @@ test('pass multiple record queries at once', async () => {
     },
   ]);
 });
+
+test('count all records of all models', async () => {
+  const queries: Array<Query> = [
+    {
+      count: {
+        all: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'team',
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT (COUNT(*)) as "amount" FROM "accounts"`,
+      params: [],
+      returning: true,
+    },
+    {
+      statement: `SELECT (COUNT(*)) as "amount" FROM "teams"`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults);
+
+  console.log('result', result);
+});

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -227,7 +227,7 @@ test('count all records of all models', async () => {
       slug: 'account',
     },
     {
-      slug: 'team',
+      slug: 'beach',
     },
   ];
 
@@ -240,14 +240,21 @@ test('count all records of all models', async () => {
       returning: true,
     },
     {
-      statement: `SELECT (COUNT(*)) as "amount" FROM "teams"`,
+      statement: `SELECT (COUNT(*)) as "amount" FROM "beaches"`,
       params: [],
       returning: true,
     },
   ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
-  const result = transaction.formatResults(rawResults);
+  const result = transaction.formatResults(rawResults)[0];
 
-  console.log('result', result);
+  expect(result).toMatchObject({
+    accounts: {
+      amount: 2,
+    },
+    beaches: {
+      amount: 4,
+    },
+  });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -213,6 +213,100 @@ test('pass multiple record queries at once', async () => {
   ]);
 });
 
+test('get all records of all models', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        all: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'team',
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "accounts"`,
+      params: [],
+      returning: true,
+    },
+    {
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "teams"`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0];
+
+  expect(result).toMatchObject({
+    accounts: {
+      records: [
+        {
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            locked: false,
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        },
+        {
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            locked: false,
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        },
+      ],
+      modelFields: expect.objectContaining({
+        id: 'string',
+      }),
+    },
+    teams: {
+      records: [
+        {
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            locked: false,
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        },
+        {
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            locked: false,
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        },
+      ],
+      modelFields: expect.objectContaining({
+        id: 'string',
+      }),
+    },
+  });
+});
+
 test('count all records of all models', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
In SQLite, it's not possible to dynamically generate a list of SQL statements for a list of tables. Instead, the tables that are being addressed must be known ahead of time.

To make this possible on RONIN, we introduced the keyword `all` as a model slug a long time ago, which makes the query run for all models, instead of just one model.

I'm now bringing this keyword back, because I consider it to be the most effective way to run a query for all models, at the moment of writing. As an example, this is how the rows in all tables can be counted at once:

```typescript
count.all()
```

Similarly, this is how you load the most recently created 2 records of all tables:

```typescript
get.all({
  orderedBy: { descending: ['ronin.createdAt'] },
  limitedTo: 2
});
```

We will evolve this syntax further in the future.