### PR TITLE
Correctly inline field values

### DIFF
--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -126,12 +126,12 @@ export const prepareStatementValue = (
   // which is desired in cases where there is no risk of SQL injection and where the
   // values must be plainly visible for manual human inspection.
   if (!statementParams) {
-    if (typeof value === 'boolean') return value ? '1' : '0';
+    if (typeof value === 'string') return `'${value}'`;
 
     const valueString =
       typeof value === 'object'
         ? `json('${JSON.stringify(value, replaceJSON)}')`
-        : `'${value!.toString()}'`;
+        : value!.toString();
 
     return valueString;
   }

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -126,6 +126,8 @@ export const prepareStatementValue = (
   // which is desired in cases where there is no risk of SQL injection and where the
   // values must be plainly visible for manual human inspection.
   if (!statementParams) {
+    if (typeof value === 'boolean') return value ? '1' : '0';
+
     const valueString =
       typeof value === 'object'
         ? `json('${JSON.stringify(value, replaceJSON)}')`

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -149,7 +149,7 @@ test('create new model', () => {
     {
       params: [],
       statement:
-        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES (\'2000\'); END',
+        'CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES (2000); END',
     },
     {
       statement:
@@ -1316,7 +1316,7 @@ test('create new trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES ('2000'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES (2000); END`,
       params: [],
     },
     {
@@ -1375,7 +1375,7 @@ test('create new trigger for creating records with targeted fields', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER UPDATE OF ("email") ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES ('2000'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER UPDATE OF ("email") ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES (2000); END`,
       params: [],
     },
     {
@@ -1441,7 +1441,7 @@ test('create new trigger for creating records with multiple effects', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES ('2000'); INSERT INTO "candidates" ("year") VALUES ('2020'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "accounts" BEGIN INSERT INTO "signups" ("year") VALUES (2000); INSERT INTO "candidates" ("year") VALUES (2020); END`,
       params: [],
     },
     {
@@ -1508,7 +1508,7 @@ test('create new per-record trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 0); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', false); END`,
       params: [],
     },
     {
@@ -1644,7 +1644,7 @@ test('create new per-record trigger with filters for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN (NEW."handle" LIKE '%_hidden') BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 0); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN (NEW."handle" LIKE '%_hidden') BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', false); END`,
       params: [],
     },
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1508,7 +1508,7 @@ test('create new per-record trigger for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 'false'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 0); END`,
       params: [],
     },
     {
@@ -1644,7 +1644,7 @@ test('create new per-record trigger with filters for creating records', () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN (NEW."handle" LIKE '%_hidden') BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 'false'); END`,
+      statement: `CREATE TRIGGER "trigger_slug" AFTER INSERT ON "teams" FOR EACH ROW WHEN (NEW."handle" LIKE '%_hidden') BEGIN INSERT INTO "members" ("account", "role", "pending") VALUES (NEW."createdBy", 'owner', 0); END`,
       params: [],
     },
     {

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -139,7 +139,7 @@ test('inline statement parameters containing boolean', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "pending" FROM "members" WHERE "pending" = 0 LIMIT 1`,
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "pending" FROM "members" WHERE "pending" = false LIMIT 1`,
       params: [],
       returning: true,
     },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -107,6 +107,52 @@ test('inline statement parameters containing serialized expression', async () =>
   });
 });
 
+test('inline statement parameters containing boolean', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        member: {
+          with: {
+            pending: false,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'member',
+      fields: [
+        {
+          slug: 'pending',
+          type: 'boolean',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, {
+    models,
+    inlineParams: true,
+  });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "pending" FROM "members" WHERE "pending" = 0 LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toMatchObject({
+    pending: false,
+  });
+});
+
 // Ensure that default fields are not repeated if they are already present.
 test('provide models containing default fields', async () => {
   const queries: Array<Query> = [


### PR DESCRIPTION
This change ensures that statement parameters are correctly inlined when the `inlineParams` config option is used.

Previously, booleans and integers were incorrectly inlined as strings, for example.