### PR TITLE
Correctly assert empty fields

### DIFF
--- a/src/instructions/with.ts
+++ b/src/instructions/with.ts
@@ -10,7 +10,7 @@ import { composeConditions } from '@/src/utils/statement';
  *
  * @returns The SQL assertion syntax for the given value.
  */
-const getMatcher = (value: unknown, negative: boolean): string => {
+export const getMatcher = (value: unknown, negative: boolean): string => {
   if (negative) {
     if (value === null) return 'IS NOT';
     return '!=';

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -4,6 +4,7 @@ import {
   type WithFilters,
   type WithValue,
   type WithValueOptions,
+  getMatcher,
 } from '@/src/instructions/with';
 import { getFieldFromModel, getModelBySlug } from '@/src/model';
 import type { Model, ModelField } from '@/src/types/model';
@@ -231,7 +232,7 @@ export const composeFieldValues = (
   // Determine if the value of the field is a symbol.
   const symbol = getQuerySymbol(value);
 
-  let conditionMatcher = '=';
+  let conditionMatcher = instructionName === 'to' ? '=' : getMatcher(value, false);
   let conditionValue: unknown = value;
 
   // Obtain the SQL syntax that should be used for the current condition.

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -874,6 +874,47 @@ test('get single record with blob field', async () => {
   expect(result.record?.avatar).toHaveProperty('meta.type', 'image/png');
 });
 
+test('get single record with empty field', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        beach: {
+          with: {
+            region: null,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'beach',
+      fields: [
+        {
+          slug: 'region',
+          type: 'string',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.locked", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "region" FROM "beaches" WHERE "region" IS NULL LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toHaveProperty('region', null);
+});
+
 test('get single record with one of fields', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
Previously, when retrieving records, empty fields were asserted using `= NULL`, which is not valid in SQLite.

Instead, we are now correctly using `IS NULL`.