### PR TITLE
Correctly format empty boolean fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ class Transaction {
         if (field.type === 'json' || field.type === 'blob') {
           newValue = JSON.parse(newValue as string);
         } else if (field.type === 'boolean') {
-          newValue = Boolean(newValue);
+          newValue = newValue === null ? newValue : Boolean(newValue);
         }
 
         // If the query is used to alter the database schema, the result of the query

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -423,10 +423,10 @@ test('get multiple records before cursor ordered by empty boolean field', async 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as MultipleRecordResult;
 
-  const firstRecordSwimming = false;
+  const firstRecordSwimming: null = null;
   const firstRecordTime = new Date('2024-12-10T10:47:58.079Z');
 
-  const lastRecordSwimming = false;
+  const lastRecordSwimming: null = null;
   const lastRecordTime = new Date('2024-12-09T10:47:58.079Z');
 
   expect(result.records).toEqual([
@@ -454,8 +454,8 @@ test('get multiple records before cursor ordered by empty boolean field', async 
     },
   ]);
 
-  expect(result.moreBefore).toBe(`${firstRecordSwimming},${firstRecordTime.getTime()}`);
-  expect(result.moreAfter).toBe(`${lastRecordSwimming},${lastRecordTime.getTime()}`);
+  expect(result.moreBefore).toBe(`RONIN_NULL,${firstRecordTime.getTime()}`);
+  expect(result.moreAfter).toBe(`RONIN_NULL,${lastRecordTime.getTime()}`);
 });
 
 test('get multiple records before cursor ordered by empty number field', async () => {

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -786,6 +786,88 @@ test('get single record with link field and id with condition', async () => {
   expect(result.record?.account).toBe('acc_39h8fhe98hefah9j');
 });
 
+test('get single record with boolean field', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        member: {
+          with: {
+            pending: false,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'member',
+      fields: [
+        {
+          slug: 'pending',
+          type: 'boolean',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "pending" FROM "members" WHERE "pending" = ?1 LIMIT 1`,
+      params: [0],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toHaveProperty('pending', false);
+});
+
+test('get single record with boolean field (empty)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        member: {
+          with: {
+            someEmptyField: null,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'member',
+      fields: [
+        {
+          slug: 'someEmptyField',
+          type: 'boolean',
+        },
+      ],
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "someEmptyField" FROM "members" WHERE "someEmptyField" IS NULL LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toHaveProperty('someEmptyField', null);
+});
+
 test('get single record with json field', async () => {
   const queries: Array<Query> = [
     {
@@ -874,7 +956,7 @@ test('get single record with blob field', async () => {
   expect(result.record?.avatar).toHaveProperty('meta.type', 'image/png');
 });
 
-test('get single record with empty field', async () => {
+test('get single record with string field (empty)', async () => {
   const queries: Array<Query> = [
     {
       get: {


### PR DESCRIPTION
This change ensures that empty boolean fields are formatted as `null` instead of `false`.