### PR TITLE
Temporarily inline default value expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ new Transaction(queries, {
   // Instead of returning an array of parameters for every statement (which allows for
   // preventing SQL injections), all parameters are inlined directly into the SQL strings.
   // This option should only be used if the generated SQL will be manually verified.
-  inlineParams: true
+  inlineParams: true,
+
+  // By default, the compiler relies on dynamic column default values for computing the
+  // values of all meta fields (such as `id`, `ronin.createdAt`, etc). In order to compute
+  // those values at the time of insertion instead, use this option.
+  inlineDefaults: true
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,9 @@ class Transaction {
         query,
         modelsWithPresets,
         options?.inlineParams ? null : [],
-        { inlineDefaults: options?.inlineDefaults },
+
+        // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+        { inlineDefaults: options?.inlineDefaults || false },
       );
 
       // Every query can only produce one main statement (which can return output), but

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ interface TransactionOptions {
    * separating them out into a dedicated `params` array.
    */
   inlineParams?: boolean;
+  /**
+   * Whether to compute default field values as part of the generated statement.
+   */
+  inlineDefaults?: boolean;
 }
 
 class Transaction {
@@ -109,6 +113,7 @@ class Transaction {
         query,
         modelsWithPresets,
         options?.inlineParams ? null : [],
+        { inlineDefaults: options?.inlineDefaults },
       );
 
       // Every query can only produce one main statement (which can return output), but

--- a/src/instructions/including.ts
+++ b/src/instructions/including.ts
@@ -29,7 +29,13 @@ export const handleIncluding = (
   options: {
     /** The path on which the selected fields should be mounted in the final record. */
     mountingPath?: InternalModelField['mountingPath'];
-  } = {},
+    /**
+     * Whether to compute default field values as part of the generated statement.
+     */
+    inlineDefaults: boolean;
+  } = {
+    inlineDefaults: false,
+  },
 ): {
   statement: string;
   tableSubQuery?: string;
@@ -107,7 +113,7 @@ export const handleIncluding = (
         },
         models,
         statementParams,
-        { parentModel: model },
+        { parentModel: model, inlineDefaults: options.inlineDefaults },
       );
 
       relatedTableSelector = `(${subSelect.main.statement})`;
@@ -149,7 +155,7 @@ export const handleIncluding = (
         statementParams,
         subSingle,
         modifiableQueryInstructions.including,
-        { mountingPath: subMountingPath },
+        { mountingPath: subMountingPath, inlineDefaults: options.inlineDefaults },
       );
 
       statement += ` ${subIncluding.statement}`;

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -43,7 +43,11 @@ export const handleSelecting = (
   options: {
     /** The path on which the selected fields should be mounted in the final record. */
     mountingPath?: InternalModelField['mountingPath'];
-  } = {},
+    /**
+     * Whether to compute default field values as part of the generated statement.
+     */
+    inlineDefaults: boolean;
+  } = { inlineDefaults: false },
 ): { columns: string; isJoining: boolean; selectedFields: Array<InternalModelField> } => {
   let isJoining = false;
 
@@ -104,6 +108,7 @@ export const handleSelecting = (
         if (queryType === 'count') {
           const subSelect = compileQueryInput(symbol.value, models, statementParams, {
             parentModel: { ...model, tableAlias: model.table },
+            inlineDefaults: options.inlineDefaults,
           });
 
           selectedFields.push({

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -110,7 +110,10 @@ export const handleTo = (
       statement = `(${columns.join(', ')}) `;
     }
 
-    statement += compileQueryInput(symbol.value, models, statementParams).main.statement;
+    statement += compileQueryInput(symbol.value, models, statementParams, {
+      // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+      inlineDefaults: options?.inlineDefaults || false,
+    }).main.statement;
     return statement;
   }
 
@@ -156,7 +159,8 @@ export const handleTo = (
           },
           models,
           [],
-          { returning: false },
+          // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+          { returning: false, inlineDefaults: options?.inlineDefaults || false },
         ).main;
 
         // We are passing `after: true` here to ensure that the dependency statement is

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -24,6 +24,7 @@ import type {
 } from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
+  ID_EXPRESSION,
   MODEL_ENTITY_ERROR_CODES,
   QUERY_SYMBOLS,
   RoninError,
@@ -211,12 +212,7 @@ export const getSystemFields = (idPrefix: Model['idPrefix']): Array<ModelField> 
     name: 'ID',
     type: 'string',
     slug: 'id',
-    defaultValue: {
-      // Since default values in SQLite cannot rely on other columns, we unfortunately
-      // cannot rely on the `idPrefix` column here. Instead, we need to inject it directly
-      // into the expression as a static string.
-      [QUERY_SYMBOLS.EXPRESSION]: `'${idPrefix}_' || lower(substr(hex(randomblob(12)), 1, 16))`,
-    },
+    defaultValue: ID_EXPRESSION(idPrefix),
   },
   {
     name: 'RONIN - Created At',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -54,6 +54,15 @@ export const CURRENT_TIME_EXPRESSION = {
   [QUERY_SYMBOLS.EXPRESSION]: `strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'`,
 };
 
+export const ID_EXPRESSION = (
+  idPrefix: string,
+): Record<typeof QUERY_SYMBOLS.EXPRESSION, string> => ({
+  // Since default values in SQLite cannot rely on other columns, we unfortunately
+  // cannot rely on the `idPrefix` column here. Instead, we need to inject it directly
+  // into the expression as a static string.
+  [QUERY_SYMBOLS.EXPRESSION]: `'${idPrefix}_' || lower(substr(hex(randomblob(12)), 1, 16))`,
+});
+
 // A regular expression for splitting up the components of a field mounting path, meaning
 // the path within a record under which a particular field's value should be mounted.
 const MOUNTING_PATH_SUFFIX = /(.*?)(\{(\d+)\})?$/;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -48,6 +48,10 @@ export const compileQueryInput = (
      * the parent model in the nested query (the current query).
      */
     parentModel?: Model;
+    /**
+     * Whether to compute default field values as part of the generated statement.
+     */
+    inlineDefaults?: boolean;
   },
 ): {
   dependencies: Array<InternalDependencyStatement>;
@@ -191,7 +195,7 @@ export const compileQueryInput = (
       queryType,
       dependencyStatements,
       { with: instructions!.with, to: instructionValue },
-      options?.parentModel,
+      options,
     );
 
     statement += `${toStatement} `;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,7 +51,7 @@ export const compileQueryInput = (
     /**
      * Whether to compute default field values as part of the generated statement.
      */
-    inlineDefaults?: boolean;
+    inlineDefaults: boolean;
   },
 ): {
   dependencies: Array<InternalDependencyStatement>;
@@ -71,6 +71,10 @@ export const compileQueryInput = (
     dependencyStatements,
     statementParams,
     defaultQuery,
+    {
+      // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+      inlineDefaults: options?.inlineDefaults || false,
+    },
   );
 
   // If no further query processing should happen, we need to return early.
@@ -121,6 +125,9 @@ export const compileQueryInput = (
       selecting: instructions?.selecting,
       including: instructions?.including,
     },
+
+    // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+    { inlineDefaults: options?.inlineDefaults || false },
   );
 
   let statement = '';


### PR DESCRIPTION
This change ensures that default values can be generated as part of the SQL statement, instead of requiring the database to generate them.