### PR TITLE
Do not re-generate model attributes if slug changes

### DIFF
--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -125,6 +125,8 @@ export const addDefaultModelAttributes = (model: PartialModel, isNew: boolean): 
   if (isNew && !copiedModel.id) copiedModel.id = getModelIdentifier();
 
   for (const [setting, base, generator] of modelAttributes) {
+    if (!isNew && setting !== 'pluralSlug' && setting !== 'table') continue;
+
     // If a custom value was provided for the setting, or the setting from which the current
     // one can be generated is not available, skip the generation.
     if (copiedModel[setting] || !copiedModel[base]) continue;

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -352,8 +352,8 @@ test('alter existing model (slug)', () => {
       params: [],
     },
     {
-      statement: `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?7 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: ['user', 'users', 'User', 'Users', 'use', 'users', 'account'],
+      statement: `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "table" = ?3, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?4 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
+      params: ['user', 'users', 'users', 'account'],
       returning: true,
     },
   ]);
@@ -402,8 +402,8 @@ test('alter existing model (slug) that has system models associated with it', ()
       params: [],
     },
     {
-      statement: `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?7 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: ['account', 'accounts', 'Account', 'Accounts', 'acc', 'accounts', 'user'],
+      statement: `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "table" = ?3, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?4 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
+      params: ['account', 'accounts', 'accounts', 'user'],
       returning: true,
     },
   ]);
@@ -567,7 +567,7 @@ test('query a model that was just updated', () => {
   // order in which the queries are provided.
   expect(transaction.statements.map(({ statement }) => statement)).toEqual([
     'ALTER TABLE "accounts" RENAME TO "users"',
-    `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "name" = ?3, "pluralName" = ?4, "idPrefix" = ?5, "table" = ?6, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?7 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
+    `UPDATE "ronin_schema" SET "slug" = ?1, "pluralSlug" = ?2, "table" = ?3, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?4 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
     'SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "users" LIMIT 1',
   ]);
 });


### PR DESCRIPTION
This change ensures that updating the `slug` of a model does not cause its name, plural name, or other attributes to be re-generated automatically.

Only the plural slug and table name of a model will be re-generated in that case.