### PR TITLE
Add index fields type guards

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -143,7 +143,7 @@ export type ModelIndex<
   /**
    * The list of fields in the model for which the index should be created.
    */
-  fields: Array<ModelIndexField<T>>;
+  fields: [ModelIndexField<T>, ...Array<ModelIndexField<T>>];
   /**
    * The identifier of the index.
    */

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -2067,6 +2067,7 @@ test('try to create new index without fields', () => {
           index: {
             slug: 'indexSlug',
             unique: true,
+            // @ts-expect-error This property already includes a strict type guard
             fields: [],
           },
         },


### PR DESCRIPTION
As part of the ongoing effort to improve our types across all packages, this is a small improvement to model index types that makes it such that an index MUST include at least one field.