### PR TITLE
Allow for passing trigger effects as query symbols

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1053,11 +1053,18 @@ export const transformMetaQuery = (
 
       // Compile the effect queries into SQL statements.
       const effectStatements = trigger.effects.map((effectQuery) => {
-        return compileQueryInput(effectQuery, models, null, {
-          returning: false,
-          parentModel: existingModel,
-          inlineDefaults: options.inlineDefaults,
-        }).main.statement;
+        return compileQueryInput(
+          QUERY_SYMBOLS.QUERY in effectQuery
+            ? (effectQuery[QUERY_SYMBOLS.QUERY] as Query)
+            : (effectQuery as Query),
+          models,
+          null,
+          {
+            returning: false,
+            parentModel: existingModel,
+            inlineDefaults: options.inlineDefaults,
+          },
+        ).main.statement;
       });
 
       statementParts.push('BEGIN');

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1053,17 +1053,11 @@ export const transformMetaQuery = (
 
       // Compile the effect queries into SQL statements.
       const effectStatements = trigger.effects.map((effectQuery) => {
-        return compileQueryInput(
-          // @ts-expect-error - The query is always wrapped in a `QUERY_SYMBOLS.QUERY` object.
-          effectQuery[QUERY_SYMBOLS.QUERY],
-          models,
-          null,
-          {
-            returning: false,
-            parentModel: existingModel,
-            inlineDefaults: options.inlineDefaults,
-          },
-        ).main.statement;
+        return compileQueryInput(effectQuery[QUERY_SYMBOLS.QUERY], models, null, {
+          returning: false,
+          parentModel: existingModel,
+          inlineDefaults: options.inlineDefaults,
+        }).main.statement;
       });
 
       statementParts.push('BEGIN');

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1054,9 +1054,8 @@ export const transformMetaQuery = (
       // Compile the effect queries into SQL statements.
       const effectStatements = trigger.effects.map((effectQuery) => {
         return compileQueryInput(
-          QUERY_SYMBOLS.QUERY in effectQuery
-            ? (effectQuery[QUERY_SYMBOLS.QUERY] as Query)
-            : (effectQuery as Query),
+          // @ts-expect-error - The query is always wrapped in a `QUERY_SYMBOLS.QUERY` object.
+          effectQuery[QUERY_SYMBOLS.QUERY],
           models,
           null,
           {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -4,6 +4,7 @@ import type {
   Query,
   WithInstruction,
 } from '@/src/types/query';
+import type { QUERY_SYMBOLS } from '@/src/utils/helpers';
 
 type ModelFieldCollation = 'BINARY' | 'NOCASE' | 'RTRIM';
 
@@ -179,7 +180,7 @@ export type ModelTrigger<
   /** When the trigger should fire in the case that a matching query is executed. */
   when: 'BEFORE' | 'DURING' | 'AFTER';
   /** A list of queries that should be executed when the trigger fires. */
-  effects: Array<Query>;
+  effects: Array<Record<typeof QUERY_SYMBOLS.QUERY, Query>>;
   /** A list of field slugs for which the trigger should fire. */
   fields?: Array<ModelTriggerField<T>>;
   /**

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -55,10 +55,12 @@ test('create new model', () => {
       action: 'INSERT',
       effects: [
         {
-          add: {
-            signup: {
-              with: {
-                year: 2000,
+          [QUERY_SYMBOLS.QUERY]: {
+            add: {
+              signup: {
+                with: {
+                  year: 2000,
+                },
               },
             },
           },
@@ -1269,10 +1271,12 @@ test('create new trigger for creating records', () => {
     action: 'INSERT',
     effects: [
       {
-        add: {
-          signup: {
-            with: {
-              year: 2000,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            signup: {
+              with: {
+                year: 2000,
+              },
             },
           },
         },
@@ -1325,10 +1329,12 @@ test('create new trigger for creating records with targeted fields', () => {
     action: 'UPDATE',
     effects: [
       {
-        add: {
-          signup: {
-            with: {
-              year: 2000,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            signup: {
+              with: {
+                year: 2000,
+              },
             },
           },
         },
@@ -1389,19 +1395,23 @@ test('create new trigger for creating records with multiple effects', () => {
     action: 'INSERT',
     effects: [
       {
-        add: {
-          signup: {
-            with: {
-              year: 2000,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            signup: {
+              with: {
+                year: 2000,
+              },
             },
           },
         },
       },
       {
-        add: {
-          candidate: {
-            with: {
-              year: 2020,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            candidate: {
+              with: {
+                year: 2020,
+              },
             },
           },
         },
@@ -1460,14 +1470,16 @@ test('create new per-record trigger for creating records', () => {
     action: 'INSERT',
     effects: [
       {
-        add: {
-          member: {
-            with: {
-              account: {
-                [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            member: {
+              with: {
+                account: {
+                  [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+                },
+                role: 'owner',
+                pending: false,
               },
-              role: 'owner',
-              pending: false,
             },
           },
         },
@@ -1525,11 +1537,13 @@ test('create new per-record trigger for removing records', () => {
     action: 'DELETE',
     effects: [
       {
-        remove: {
-          members: {
-            with: {
-              account: {
-                [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_OLD}createdBy`,
+        [QUERY_SYMBOLS.QUERY]: {
+          remove: {
+            members: {
+              with: {
+                account: {
+                  [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_OLD}createdBy`,
+                },
               },
             },
           },
@@ -1589,14 +1603,16 @@ test('create new per-record trigger with filters for creating records', () => {
     action: 'INSERT',
     effects: [
       {
-        add: {
-          member: {
-            with: {
-              account: {
-                [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+        [QUERY_SYMBOLS.QUERY]: {
+          add: {
+            member: {
+              with: {
+                account: {
+                  [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD_PARENT_NEW}createdBy`,
+                },
+                role: 'owner',
+                pending: false,
               },
-              role: 'owner',
-              pending: false,
             },
           },
         },
@@ -1674,7 +1690,9 @@ test('drop existing trigger', () => {
           action: 'INSERT',
           effects: [
             {
-              add: { member: { with: { account: 'test' } } },
+              [QUERY_SYMBOLS.QUERY]: {
+                add: { member: { with: { account: 'test' } } },
+              },
             },
           ],
         },
@@ -2000,12 +2018,14 @@ test('try to drop a system field', () => {
 });
 
 test('try to create new trigger with targeted fields and wrong action', () => {
-  const effectQueries = [
+  const effectQueries: ModelTrigger['effects'] = [
     {
-      add: {
-        signup: {
-          with: {
-            year: 2000,
+      [QUERY_SYMBOLS.QUERY]: {
+        add: {
+          signup: {
+            with: {
+              year: 2000,
+            },
           },
         },
       },


### PR DESCRIPTION
The current implementation of the syntax package wraps queries within `trigger.effects` using a query symbol. This causes issues with the compiler, as it incorrectly interprets the query symbol as a query type, such as add or create, due to object destructuring. This PR addresses this issue to ensure proper handling of queries by the compiler.