### PR TITLE
Ensure that models are altered reliably

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -850,7 +850,7 @@ export const transformMetaQuery = (
 
   // Entities can only be created, altered, or dropped on existing models, so the model
   // is guaranteed to exist.
-  const modelBeforeUpdate = structuredClone(model as Model);
+  const modelBeforeUpdate = structuredClone(JSON.parse(JSON.stringify(model)) as Model);
   const existingModel = model as Model;
 
   const pluralType = PLURAL_MODEL_ENTITIES[entity];


### PR DESCRIPTION
I am currently addressing a bug that prevents models from being cloned. To resolve this issue, we are utilizing `JSON.parse(JSON.stringify())` to ensure that the models can be properly cloned.

