### PR TITLE
Avoid repeating model entity slug

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1076,7 +1076,9 @@ export const transformMetaQuery = (
 
   switch (action) {
     case 'create': {
-      const value = prepareStatementValue(statementParams, jsonValue);
+      const { slug, ...entityValue } = jsonValue as ModelEntity;
+      const value = prepareStatementValue(statementParams, entityValue);
+
       json = `json_insert(${field}, '$.${slug}', ${value})`;
 
       // Add the newly created entity to the model.

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -642,7 +642,10 @@ test('create new field', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify({ type: 'string', name: 'Email' }), 'account'],
+      params: [
+        JSON.stringify({ ...omit(field, ['slug']), type: 'string', name: 'Email' }),
+        'account',
+      ],
       returning: true,
     },
   ]);

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -18,7 +18,7 @@ import {
 import { getSystemFields } from '@/src/model';
 import { slugToName } from '@/src/model/defaults';
 import type { MultipleRecordResult } from '@/src/types/result';
-import { QUERY_SYMBOLS, RoninError } from '@/src/utils/helpers';
+import { QUERY_SYMBOLS, RoninError, omit } from '@/src/utils/helpers';
 
 test('create new model', () => {
   const fields: Model['fields'] = {
@@ -642,7 +642,7 @@ test('create new field', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.email', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify({ ...field, type: 'string', name: 'Email' }), 'account'],
+      params: [JSON.stringify({ type: 'string', name: 'Email' }), 'account'],
       returning: true,
     },
   ]);
@@ -688,7 +688,7 @@ test('create new field with options', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.account', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify({ ...field, name: 'Account' }), 'member'],
+      params: [JSON.stringify({ ...omit(field, ['slug']), name: 'Account' }), 'member'],
       returning: true,
     },
   ]);
@@ -728,7 +728,10 @@ test('create new field with many-cardinality relationship', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.followers', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify({ ...field, name: 'Followers' }), 'account'],
+      params: [
+        JSON.stringify({ ...omit(field, ['slug']), name: 'Followers' }),
+        'account',
+      ],
       returning: true,
     },
   ]);
@@ -1036,7 +1039,7 @@ test('create new index', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(index), 'account'],
+      params: [JSON.stringify(omit(index, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1086,7 +1089,7 @@ test('create new index with filter', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(index), 'account'],
+      params: [JSON.stringify(omit(index, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1132,7 +1135,7 @@ test('create new index with field expressions', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(index), 'account'],
+      params: [JSON.stringify(omit(index, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1179,7 +1182,7 @@ test('create new index with ordered and collated fields', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(index), 'account'],
+      params: [JSON.stringify(omit(index, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1225,7 +1228,7 @@ test('create new unique index', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "indexes" = json_insert("indexes", '$.indexSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(index), 'account'],
+      params: [JSON.stringify(omit(index, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1324,7 +1327,7 @@ test('create new trigger for creating records', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'account'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1390,7 +1393,7 @@ test('create new trigger for creating records with targeted fields', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'account'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1465,7 +1468,7 @@ test('create new trigger for creating records with multiple effects', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'account'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'account'],
       returning: true,
     },
   ]);
@@ -1532,7 +1535,7 @@ test('create new per-record trigger for creating records', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'team'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'team'],
       returning: true,
     },
   ]);
@@ -1598,7 +1601,7 @@ test('create new per-record trigger for removing records', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'team'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'team'],
       returning: true,
     },
   ]);
@@ -1671,7 +1674,7 @@ test('create new per-record trigger with filters for creating records', () => {
     },
     {
       statement: `UPDATE "ronin_schema" SET "triggers" = json_insert("triggers", '$.triggerSlug', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(trigger), 'team'],
+      params: [JSON.stringify(omit(trigger, ['slug'])), 'team'],
       returning: true,
     },
   ]);
@@ -1760,7 +1763,7 @@ test('create new preset', () => {
   expect(transaction.statements).toEqual([
     {
       statement: `UPDATE "ronin_schema" SET "presets" = json_insert("presets", '$.companyEmployees', ?1), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
-      params: [JSON.stringify(preset), 'account'],
+      params: [JSON.stringify(omit(preset, ['slug'])), 'account'],
       returning: true,
     },
   ]);


### PR DESCRIPTION
This change ensures that, when a new model entity (such as a field) is created, we only store its slug once.