### PR TITLE
Ensure correct record metadata

### DIFF
--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -63,7 +63,7 @@ export const handleTo = (
       ? {
           // If records are being created, set their creation time.
           ...(queryType === 'add' && { createdAt: currentTime }),
-          // If records are being updated or craeted, bump their update time.
+          // If records are being updated or created, bump their update time.
           updatedAt: currentTime,
           // Allow for overwriting the default values provided above.
           ...(toInstruction.ronin as object),

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -3,6 +3,7 @@ import {
   getFieldFromModel,
   getModelBySlug,
 } from '@/src/model';
+import { getRecordIdentifier } from '@/src/model/defaults';
 import type { Model } from '@/src/types/model';
 import type {
   FieldValue,
@@ -11,7 +12,6 @@ import type {
 } from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
-  ID_EXPRESSION,
   flatten,
   getQuerySymbol,
   isObject,
@@ -56,7 +56,7 @@ export const handleTo = (
   // If records are being created, assign a default ID to them, unless a custom ID was
   // already provided in the query.
   if (inlineDefaultInsertionFields) {
-    defaultFields.id = toInstruction.id || ID_EXPRESSION(model.idPrefix);
+    defaultFields.id = toInstruction.id || getRecordIdentifier(model.idPrefix);
   }
 
   if (queryType === 'add' || queryType === 'set' || toInstruction.ronin) {

--- a/src/instructions/to.ts
+++ b/src/instructions/to.ts
@@ -70,6 +70,7 @@ export const handleTo = (
         }
       : {
           // If records are being updated, bump their update time.
+          // The creation time is already set using a default value in the DB.
           ...(queryType === 'set' ? { updatedAt: CURRENT_TIME_EXPRESSION } : {}),
           // Allow for overwriting the default values provided above.
           ...(toInstruction.ronin as object),

--- a/src/model/defaults.ts
+++ b/src/model/defaults.ts
@@ -106,12 +106,12 @@ const modelAttributes: Array<
 ];
 
 /**
- * Generates a unique identifier for a newly created model.
+ * Generates a unique identifier for a newly created record.
  *
  * @returns A string containing the ID.
  */
-const getModelIdentifier = (): string => {
-  return `mod_${Array.from(crypto.getRandomValues(new Uint8Array(12)))
+export const getRecordIdentifier = (prefix: string): string => {
+  return `${prefix}_${Array.from(crypto.getRandomValues(new Uint8Array(12)))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
     .slice(0, 16)
@@ -132,7 +132,7 @@ export const addDefaultModelAttributes = (model: PartialModel, isNew: boolean): 
   // Generate a unique identifier for the model. We are generating these identifiers
   // within the compiler instead of the database because the compiler needs it for
   // internal comparisons, before the resulting statements hit the database.
-  if (isNew && !copiedModel.id) copiedModel.id = getModelIdentifier();
+  if (isNew && !copiedModel.id) copiedModel.id = getRecordIdentifier('mod');
 
   for (const [setting, base, generator, mustRegenerate] of modelAttributes) {
     // If an existing model is being altered, check whether the attribute must even be

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -25,7 +25,6 @@ import type {
 } from '@/src/types/query';
 import {
   CURRENT_TIME_EXPRESSION,
-  ID_EXPRESSION,
   MODEL_ENTITY_ERROR_CODES,
   QUERY_SYMBOLS,
   RoninError,
@@ -218,7 +217,12 @@ export const getSystemFields = (idPrefix: Model['idPrefix']): Model['fields'] =>
   id: {
     name: 'ID',
     type: 'string',
-    defaultValue: ID_EXPRESSION(idPrefix),
+    defaultValue: {
+      // Since default values in SQLite cannot rely on other columns, we unfortunately
+      // cannot rely on the `idPrefix` column here. Instead, we need to inject it
+      // directly into the expression as a static string.
+      [QUERY_SYMBOLS.EXPRESSION]: `'${idPrefix}_' || lower(substr(hex(randomblob(12)), 1, 16))`,
+    },
   },
   'ronin.createdAt': {
     name: 'RONIN - Created At',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -54,15 +54,6 @@ export const CURRENT_TIME_EXPRESSION = {
   [QUERY_SYMBOLS.EXPRESSION]: `strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z'`,
 };
 
-export const ID_EXPRESSION = (
-  idPrefix: string,
-): Record<typeof QUERY_SYMBOLS.EXPRESSION, string> => ({
-  // Since default values in SQLite cannot rely on other columns, we unfortunately
-  // cannot rely on the `idPrefix` column here. Instead, we need to inject it directly
-  // into the expression as a static string.
-  [QUERY_SYMBOLS.EXPRESSION]: `'${idPrefix}_' || lower(substr(hex(randomblob(12)), 1, 16))`,
-});
-
 // A regular expression for splitting up the components of a field mounting path, meaning
 // the path within a record under which a particular field's value should be mounted.
 const MOUNTING_PATH_SUFFIX = /(.*?)(\{(\d+)\})?$/;

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'bun:test';
-import { queryEphemeralDatabase } from '@/fixtures/utils';
+import {
+  RECORD_ID_REGEX,
+  RECORD_TIMESTAMP_REGEX,
+  queryEphemeralDatabase,
+} from '@/fixtures/utils';
 import { type Model, type Query, Transaction } from '@/src/index';
 import { getSystemFields } from '@/src/model';
 import type { SingleRecordResult } from '@/src/types/result';
@@ -184,8 +188,14 @@ test('inline default values', async () => {
 
   expect(transaction.statements).toEqual([
     {
-      statement: `INSERT INTO "accounts" ("handle", "emails", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, ?2, 'acc_' || lower(substr(hex(randomblob(12)), 1, 16)), strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z', strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z') RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "emails"`,
-      params: ['elaine', '["test@site.co","elaine@site.com"]'],
+      statement: `INSERT INTO "accounts" ("handle", "emails", "id", "ronin.createdAt", "ronin.updatedAt") VALUES (?1, ?2, ?3, ?4, ?5) RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "emails"`,
+      params: [
+        'elaine',
+        '["test@site.co","elaine@site.com"]',
+        expect.stringMatching(RECORD_ID_REGEX),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+        expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+      ],
       returning: true,
     },
   ]);


### PR DESCRIPTION
This change ensures that, if the `inlineDefaults` option is passed, the metadata of records is generated correctly.