### PR TITLE
Allow for resolving related models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,12 @@ import type {
   Model as PrivateModel,
   PublicModel,
 } from '@/src/types/model';
-import type { InternalStatement, Query, Statement } from '@/src/types/query';
+import type {
+  AllQueryInstructions,
+  InternalStatement,
+  Query,
+  Statement,
+} from '@/src/types/query';
 import type {
   ExpandedResult,
   MultipleRecordResult,
@@ -96,7 +101,8 @@ class Transaction {
         // If the model defined in the query is called `all`, that means we need to expand
         // the query into multiple queries: One for each model.
         if (queryModel === 'all') {
-          const { for: forInstruction, ...restInstructions } = queryInstructions || {};
+          const { for: forInstruction, ...restInstructions } = (queryInstructions ||
+            {}) as AllQueryInstructions;
 
           let modelList = modelsWithAttributes;
 

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -632,7 +632,9 @@ export const transformMetaQuery = (
   let slug =
     entity === 'model' && action === 'create'
       ? null
-      : (query[queryType]!.model as string);
+      : query[queryType] && 'model' in query[queryType]
+        ? (query[queryType].model as string)
+        : null;
   let modelSlug = slug;
 
   let jsonValue: Record<string, unknown> | undefined;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -103,7 +103,7 @@ export type InstructionSchema =
   | 'limitedTo'
   | 'using';
 
-// Query Types
+// DML Query Types
 export type GetQuery = Record<string, Omit<CombinedInstructions, 'to'> | null>;
 export type SetQuery = Record<
   string,
@@ -116,7 +116,14 @@ export type AddQuery = Record<
 export type RemoveQuery = Record<string, Omit<CombinedInstructions, 'to'>>;
 export type CountQuery = Record<string, Omit<CombinedInstructions, 'to'> | null>;
 
-// Individual Instructions
+// DML Query Types — Addressing all models
+export type AllQueryInstructions = { for?: string };
+export type AllQuery = { all: AllQueryInstructions | null };
+
+export type GetAllQuery = AllQuery;
+export type CountAllQuery = AllQuery;
+
+// DML Query Types — Individual Instructions
 export type GetInstructions = Omit<CombinedInstructions, 'to'>;
 export type SetInstructions = Omit<CombinedInstructions, 'to'> & { to: FieldSelector };
 export type AddInstructions = Omit<CombinedInstructions, 'with' | 'using'> & {
@@ -131,6 +138,7 @@ export type Instructions =
   | RemoveInstructions
   | CountInstructions;
 
+// DDL Query Types - Individual Instructions
 export type CreateQuery = {
   model: string | PublicModel;
   to?: PublicModel;
@@ -171,7 +179,7 @@ export type DropQuery = {
   model: string;
 };
 
-// Model Queries
+// DDL Query Types
 export type ModelQuery =
   | {
       create: CreateQuery;
@@ -190,8 +198,8 @@ export type QueryPaginationOptions = {
 };
 
 export type Query = {
-  get?: GetQuery;
-  set?: SetQuery;
+  get?: GetQuery | GetAllQuery;
+  set?: SetQuery | CountAllQuery;
   add?: AddQuery;
   remove?: RemoveQuery;
   count?: CountQuery;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -199,10 +199,10 @@ export type QueryPaginationOptions = {
 
 export type Query = {
   get?: GetQuery | GetAllQuery;
-  set?: SetQuery | CountAllQuery;
+  set?: SetQuery;
   add?: AddQuery;
   remove?: RemoveQuery;
-  count?: CountQuery;
+  count?: CountQuery | CountAllQuery;
 
   create?: CreateQuery;
   alter?: AlterQuery;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -302,6 +302,121 @@ test('get all records of all models', async () => {
   });
 });
 
+test('get all records of linked models', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        all: {
+          for: 'member',
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'team',
+    },
+    {
+      slug: 'member',
+      fields: {
+        account: {
+          type: 'link',
+          target: 'account',
+        },
+        team: {
+          type: 'link',
+          target: 'team',
+        },
+      },
+    },
+    // These two should not end up in the final list of SQL statements. We are listing
+    // them here to ensure that they are correctly filtered out.
+    {
+      slug: 'beach',
+    },
+    {
+      slug: 'product',
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "accounts"`,
+      params: [],
+      returning: true,
+    },
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "teams"`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0];
+
+  expect(result).toMatchObject({
+    models: {
+      accounts: {
+        records: [
+          {
+            id: expect.stringMatching(RECORD_ID_REGEX),
+            ronin: {
+              createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              createdBy: null,
+              updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              updatedBy: null,
+            },
+          },
+          {
+            id: expect.stringMatching(RECORD_ID_REGEX),
+            ronin: {
+              createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              createdBy: null,
+              updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              updatedBy: null,
+            },
+          },
+        ],
+        modelFields: expect.objectContaining({
+          id: 'string',
+        }),
+      },
+      teams: {
+        records: [
+          {
+            id: expect.stringMatching(RECORD_ID_REGEX),
+            ronin: {
+              createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              createdBy: null,
+              updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              updatedBy: null,
+            },
+          },
+          {
+            id: expect.stringMatching(RECORD_ID_REGEX),
+            ronin: {
+              createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              createdBy: null,
+              updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              updatedBy: null,
+            },
+          },
+        ],
+        modelFields: expect.objectContaining({
+          id: 'string',
+        }),
+      },
+    },
+  });
+});
+
 test('count all records of all models', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
At the moment, it is already possible to address all models at once with a single query:

```typescript
get.all();
count.all();

// etc.
```

Those queries are helpful because they avoid needing to first resolve the list of models before being able to compose queries for the resolved models. SQLite does not provide a solution for dynamically composing queries like that either, so we integrated it into the compiler instead.

The current change applies one more improvement to those queries, by allowing for only selecting the linked models of a specific model, which would otherwise not be possible:

```typescript
get.all.for('member');
```

Assuming that the "member" model, for example, has two link fields pointing to the models "account" and "team", then the `get.all` query above would only resolve the records of those two models.

The syntax is not final. The objective at the moment is to unblock our own use cases and then iterate on it further. This is also the last change of this nature that is needed (I want to keep them to a minimum).