### PR TITLE
Handle case in which no models exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -329,6 +329,7 @@ class Transaction {
     results: Array<Array<RawRow>> | Array<Array<ObjectRow>>,
     raw = false,
   ): Array<Result<RecordType>> {
+    // Only retain the results of SQL statements that are expected to return data.
     const cleanResults = results.filter((_, index) => this.statements[index].returning);
 
     return this.#internalQueries.reduce(

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,9 +422,10 @@ class Transaction {
         const { queryModel } = splitQuery(query);
 
         if (queryModel === 'all') {
+          const modelList = this.models.filter((model) => model.slug !== ROOT_MODEL.slug);
           const models: ExpandedResult<RecordType>['models'] = {};
 
-          for (const model of this.models) {
+          for (const model of modelList) {
             const defaultRows = cleanResults[resultIndex];
 
             // If the provided results are raw (rows being arrays of values, which is the most

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,7 @@ class Transaction {
     });
 
     return cleanResults.reduce(
-      (finalResults, defaultRows, index) => {
+      (finalResults: Array<Result<RecordType>>, defaultRows, index) => {
         const { query, selectedFields, expansionIndex } = this.#internalQueries[index];
 
         // If the provided results are raw (rows being arrays of values, which is the most
@@ -386,7 +386,7 @@ class Transaction {
 
         // The query is expected to count records.
         if (queryType === 'count') {
-          return addResult({ amount: rows[0][0] as number });
+          return addResult({ amount: rows[0][0] as unknown as number });
         }
 
         // Whether the query will interact with a single record, or multiple at the same time.

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,10 +340,10 @@ class Transaction {
         // ideal format in terms of performance, since the driver doesn't need to format
         // the rows in that case), we can already continue processing them further.
         //
-        // If the provided results were already formatted by the driver (rows being objects),
-        // we need to normalize them into the raw format first, before they can be processed,
-        // since the object format provided by the driver does not match the RONIN record
-        // format expected by developers.
+        // If the provided results were already formatted by the driver (rows being
+        // objects), we need to normalize them into the raw format first, before they can
+        // be processed, since the object format provided by the driver does not match
+        // the RONIN record format expected by developers.
         const rows = raw
           ? (defaultRows as Array<Array<RawRow>>)
           : (defaultRows.map((row) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,14 +329,12 @@ class Transaction {
     results: Array<Array<RawRow>> | Array<Array<ObjectRow>>,
     raw = false,
   ): Array<Result<RecordType>> {
-    const cleanResults = results.filter((_rows, index) => {
-      const { returning } = this.statements[index];
-      return returning;
-    });
+    const cleanResults = results.filter((_, index) => this.statements[index].returning);
 
-    return cleanResults.reduce(
-      (finalResults: Array<Result<RecordType>>, defaultRows, index) => {
-        const { query, selectedFields, expansionIndex } = this.#internalQueries[index];
+    return this.#internalQueries.reduce(
+      (finalResults: Array<Result<RecordType>>, internalQuery, index) => {
+        const { query, selectedFields, expansionIndex } = internalQuery;
+        const defaultRows = cleanResults[index];
 
         // If the provided results are raw (rows being arrays of values, which is the most
         // ideal format in terms of performance, since the driver doesn't need to format

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,12 +449,10 @@ class Transaction {
           const models: ExpandedResult<RecordType>['models'] = {};
 
           for (const model of modelList) {
-            const rows = absoluteResults[resultIndex++];
-
             const result = this.formatSingleResult<RecordType>(
               query,
               model,
-              rows,
+              absoluteResults[resultIndex++],
               selectedFields,
               false,
             );
@@ -464,8 +462,6 @@ class Transaction {
 
           finalResults.push({ models });
         } else {
-          const rows = absoluteResults[resultIndex++];
-
           const model = getModelBySlug(this.models, queryModel);
 
           // Whether the query will interact with a single record, or multiple at the same time.
@@ -474,7 +470,7 @@ class Transaction {
           const result = this.formatSingleResult<RecordType>(
             query,
             model,
-            rows,
+            absoluteResults[resultIndex++],
             selectedFields,
             single,
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ class Transaction {
 
       // Update the internal query with additional information.
       //
-      // In the case that a expension index is available, we want to update the original
+      // In the case that an expansion index is available, we want to update the original
       // query from which the current query was derived/expanded.
       const queryIndex = typeof expansionIndex === 'undefined' ? index : expansionIndex;
       this.#internalQueries[queryIndex].selectedFields = selectedFields;
@@ -317,7 +317,7 @@ class Transaction {
    * Formats an individual result of a query (each query has one individual result).
    *
    * @param queryType - The type of query that is being executed.
-   * @param queryInstructions - The instructions if the query that is being executed.
+   * @param queryInstructions - The instructions of the query that is being executed.
    * @param model - The model for which the query is being executed.
    * @param rows - The rows that were returned from the database for the query (in the
    * form of an array containing arrays that contain strings).

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,7 @@ class Transaction {
           const models: ExpandedResult<RecordType>['models'] = {};
 
           for (const model of modelList) {
-            const defaultRows = cleanResults[resultIndex];
+            const defaultRows = cleanResults[resultIndex++];
 
             // If the provided results are raw (rows being arrays of values, which is the most
             // ideal format in terms of performance, since the driver doesn't need to format
@@ -457,13 +457,12 @@ class Transaction {
               false,
             );
 
-            resultIndex++;
             models[model.slug] = result;
           }
 
           finalResults.push({ models });
         } else {
-          const defaultRows = cleanResults[resultIndex];
+          const defaultRows = cleanResults[resultIndex++];
 
           // If the provided results are raw (rows being arrays of values, which is the most
           // ideal format in terms of performance, since the driver doesn't need to format
@@ -499,7 +498,6 @@ class Transaction {
             single,
           );
 
-          resultIndex++;
           finalResults.push(result);
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,7 +457,7 @@ class Transaction {
               false,
             );
 
-            models[model.slug] = result;
+            models[model.pluralSlug] = result;
           }
 
           finalResults.push({ models });

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,6 +313,19 @@ class Transaction {
     return single ? (records[0] as RecordType) : (records as Array<RecordType>);
   }
 
+  /**
+   * Formats an individual result of a query (each query has one individual result).
+   *
+   * @param queryType - The type of query that is being executed.
+   * @param queryInstructions - The instructions if the query that is being executed.
+   * @param model - The model for which the query is being executed.
+   * @param rows - The rows that were returned from the database for the query (in the
+   * form of an array containing arrays that contain strings).
+   * @param selectedFields - The model fields that were selected by the query.
+   * @param single - Whether a single or multiple records are being affected by the query.
+   *
+   * @returns A formatted RONIN result for a particular query.
+   */
   formatIndividualResult<RecordType>(
     queryType: QueryType,
     queryInstructions: CombinedInstructions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,6 @@ class Transaction {
     return this.#internalQueries.reduce(
       (finalResults: Array<Result<RecordType>>, internalQuery) => {
         const { query, selectedFields } = internalQuery;
-
         const { queryType, queryModel } = splitQuery(query);
 
         // If the provided results are raw (rows being arrays of values, which is the most
@@ -464,15 +463,12 @@ class Transaction {
         } else {
           const model = getModelBySlug(this.models, queryModel);
 
-          // Whether the query will interact with a single record, or multiple at the same time.
-          const single = queryModel !== model.pluralSlug;
-
           const result = this.formatSingleResult<RecordType>(
             query,
             model,
             absoluteResults[resultIndex++],
             selectedFields,
-            single,
+            queryModel !== model.pluralSlug,
           );
 
           finalResults.push(result);

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -222,7 +222,7 @@ export interface Statement {
   returning?: boolean;
 }
 
-export interface InternalStatement extends Statement {
+export interface InternalQuery {
   /** The RONIN query for which the SQL statement was generated. */
   query: Query;
   /** The RONIN model fields that were selected for the SQL statement. */

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -227,11 +227,6 @@ export interface InternalQuery {
   query: Query;
   /** The RONIN model fields that were selected for the SQL statement. */
   selectedFields: Array<InternalModelField>;
-  /**
-   * If the associated RONIN query was automatically generated because a different
-   * RONIN query was expanded, this contains the index of the original query.
-   */
-  expansionIndex?: number;
 }
 
 export interface InternalDependencyStatement extends Statement {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -227,6 +227,11 @@ export interface InternalQuery {
   query: Query;
   /** The RONIN model fields that were selected for the SQL statement. */
   selectedFields: Array<InternalModelField>;
+  /**
+   * If the query addresses multiple models at once, this contains the list of models
+   * that are being addressed.
+   */
+  affectedModels?: Array<PublicModel['slug']>;
 }
 
 export interface InternalDependencyStatement extends Statement {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -79,7 +79,11 @@ export const compileQueryInput = (
 
   // If no further query processing should happen, we need to return early.
   if (query === null)
-    return { dependencies: [], main: dependencyStatements[0], selectedFields: [] };
+    return {
+      dependencies: [],
+      main: dependencyStatements[0],
+      selectedFields: [],
+    };
 
   // Split out the individual components of the query.
   const parsedQuery = splitQuery(query);

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -101,6 +101,8 @@ test('inline statement parameters containing serialized expression', async () =>
   ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+
+  console.log('RAW RESULTS', rawResults);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -101,8 +101,6 @@ test('inline statement parameters containing serialized expression', async () =>
   ]);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
-
-  console.log('RAW RESULTS', rawResults);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
   expect(result.record).toMatchObject({

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -493,6 +493,29 @@ test('get all records of linked models', async () => {
   });
 });
 
+test('get all records of all models with no models available', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        all: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0];
+
+  expect(result).toMatchObject({
+    models: {},
+  });
+});
+
 test('count all records of all models', async () => {
   const queries: Array<Query> = [
     {
@@ -538,5 +561,28 @@ test('count all records of all models', async () => {
         amount: 4,
       },
     },
+  });
+});
+
+test('count all records of all models with no models available', async () => {
+  const queries: Array<Query> = [
+    {
+      count: {
+        all: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0];
+
+  expect(result).toMatchObject({
+    models: {},
   });
 });


### PR DESCRIPTION
This change ensures that queries addressing all models (e.g. `get.all()`) still return correct results instead of not showing up in the results at all, in the case that no models are available.