### PR TITLE
Allow for providing model-specific instructions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -478,8 +478,8 @@ class Transaction {
         if (queryModel === 'all') {
           const models: ExpandedResult<RecordType>['models'] = {};
 
-          const { on: onInstruction, ...restInstructions } =
-            queryInstructions || ({} as AllQueryInstructions);
+          const { on: onInstruction, ...restInstructions } = (queryInstructions ||
+            {}) as AllQueryInstructions;
 
           for (const model of affectedModels) {
             const instructions = Object.assign(

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -119,7 +119,14 @@ export type CountQuery = Record<string, Omit<CombinedInstructions, 'to'> | null>
 
 // DML Query Types — Addressing all models
 export type AllQueryInstructions = {
-  for?: string;
+  /**
+   * Limit the list of models for which queries should be generated to only the models
+   * that the provided model links to.
+   */
+  for?: PublicModel['slug'];
+  /**
+   * Provide query instructions for specific models.
+   */
   on?: Record<PublicModel['slug'], Omit<CombinedInstructions, 'to'> | null>;
 };
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -118,7 +118,11 @@ export type RemoveQuery = Record<string, Omit<CombinedInstructions, 'to'>>;
 export type CountQuery = Record<string, Omit<CombinedInstructions, 'to'> | null>;
 
 // DML Query Types — Addressing all models
-export type AllQueryInstructions = { for?: string };
+export type AllQueryInstructions = {
+  for?: string;
+  on?: Record<PublicModel['slug'], Omit<CombinedInstructions, 'to'> | null>;
+};
+
 export type AllQuery = { all: AllQueryInstructions | null };
 
 export type GetAllQuery = AllQuery;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import {
+  PAGINATION_CURSOR_REGEX,
   RECORD_ID_REGEX,
   RECORD_TIMESTAMP_REGEX,
   queryEphemeralDatabase,
@@ -357,6 +358,7 @@ test('get all records of all models with instructions', async () => {
         modelFields: expect.objectContaining({
           id: 'string',
         }),
+        moreAfter: expect.stringMatching(PAGINATION_CURSOR_REGEX),
       },
       teams: {
         records: [
@@ -373,6 +375,7 @@ test('get all records of all models with instructions', async () => {
         modelFields: expect.objectContaining({
           id: 'string',
         }),
+        moreAfter: expect.stringMatching(PAGINATION_CURSOR_REGEX),
       },
     },
   });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -381,6 +381,86 @@ test('get all records of all models with instructions', async () => {
   });
 });
 
+test('get all records of all models with model-specific instructions', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        all: {
+          limitedTo: 1,
+          on: {
+            teams: {
+              limitedTo: 10,
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+    {
+      slug: 'team',
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "accounts" ORDER BY "ronin.createdAt" DESC LIMIT 2`,
+      params: [],
+      returning: true,
+    },
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "teams" ORDER BY "ronin.createdAt" DESC LIMIT 11`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0];
+
+  expect(result).toMatchObject({
+    models: {
+      accounts: {
+        records: [
+          {
+            id: expect.stringMatching(RECORD_ID_REGEX),
+            ronin: {
+              createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              createdBy: null,
+              updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+              updatedBy: null,
+            },
+          },
+        ],
+        modelFields: expect.objectContaining({
+          id: 'string',
+        }),
+        moreAfter: expect.stringMatching(PAGINATION_CURSOR_REGEX),
+      },
+      teams: {
+        records: new Array(2).fill({
+          id: expect.stringMatching(RECORD_ID_REGEX),
+          ronin: {
+            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            createdBy: null,
+            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
+            updatedBy: null,
+          },
+        }),
+        modelFields: expect.objectContaining({
+          id: 'string',
+        }),
+      },
+    },
+  });
+});
+
 test('get all records of linked models', async () => {
   const queries: Array<Query> = [
     {


### PR DESCRIPTION
This change allows for providing instructions that apply only to a specific model, when using queries that affect all models.

In other words, considering that the following query retrieves the records of all models:

```typescript
get.all();
```

The following query would then do the same, but limit the records of the "account" model to 10:

```typescript
get.all({
  on: {
    accounts: { limitedTo: 10 }
  }
});
```

This change is not necessary, since the same can be accomplished by simply using an additional, separate query.

In order to ensure perfect performance (no unnecessary queries) however, and because the additional syntax complexity is limited strictly to `all` queries, using an additional `on` query instruction is more advantageous.