### PR TITLE
Ensure correct model-specific queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,6 @@ class Transaction {
               });
           }
 
-          // Track which models are being addressed by the query, in order to ensure that
-          // its results are being formatted correctly.
-          this.#internalQueries[index].models = modelList;
-
           return modelList.map((model) => {
             const instructions = Object.assign(
               {},
@@ -182,10 +178,7 @@ class Transaction {
 
       // Update the internal query with additional information.
       this.#internalQueries[index].selectedFields.push(selectedFields);
-
-      if (this.#internalQueries[index].models.length === 0) {
-        this.#internalQueries[index].models.push(model);
-      }
+      this.#internalQueries[index].models.push(model);
     }
 
     this.models = modelsWithPresets;

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,10 +181,10 @@ class Transaction {
       this.statements.push(...subStatements);
 
       // Update the internal query with additional information.
-      this.#internalQueries[index].selectedFields = selectedFields;
+      this.#internalQueries[index].selectedFields.push(selectedFields);
 
       if (this.#internalQueries[index].models.length === 0) {
-        this.#internalQueries[index].models = [model];
+        this.#internalQueries[index].models.push(model);
       }
     }
 
@@ -481,7 +481,10 @@ class Transaction {
           const { on: onInstruction, ...restInstructions } = (queryInstructions ||
             {}) as AllQueryInstructions;
 
-          for (const model of affectedModels) {
+          for (let index = 0; index < affectedModels.length; index++) {
+            const model = affectedModels[index];
+            const fields = selectedFields[index];
+
             const instructions = Object.assign(
               {},
               restInstructions,
@@ -493,7 +496,7 @@ class Transaction {
               instructions,
               model,
               absoluteResults[resultIndex++],
-              selectedFields,
+              fields,
               false,
             );
 
@@ -503,13 +506,14 @@ class Transaction {
           finalResults.push({ models });
         } else {
           const model = affectedModels[0];
+          const fields = selectedFields[0];
 
           const result = this.formatIndividualResult<RecordType>(
             queryType,
             queryInstructions,
             model,
             absoluteResults[resultIndex++],
-            selectedFields,
+            fields,
             queryModel !== model.pluralSlug,
           );
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -238,7 +238,7 @@ export interface InternalQuery {
   /** The RONIN query for which the SQL statement was generated. */
   query: Query;
   /** The RONIN model fields that were selected for the SQL statement. */
-  selectedFields: Array<InternalModelField>;
+  selectedFields: Array<Array<InternalModelField>>;
   /** The RONIN models that are being affected by the query. */
   models: Array<PrivateModel>;
 }

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -390,6 +390,9 @@ test('get all records of all models with model-specific instructions', async () 
           on: {
             teams: {
               limitedTo: 10,
+              // It is important to test an instruction here that is not already present
+              // in the global instructions, to make sure it is working correctly.
+              selecting: ['id'],
             },
           },
         },
@@ -415,7 +418,7 @@ test('get all records of all models with model-specific instructions', async () 
       returning: true,
     },
     {
-      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy" FROM "teams" ORDER BY "ronin.createdAt" DESC LIMIT 11`,
+      statement: `SELECT "id" FROM "teams" ORDER BY "ronin.createdAt" DESC LIMIT 11`,
       params: [],
       returning: true,
     },
@@ -446,12 +449,6 @@ test('get all records of all models with model-specific instructions', async () 
       teams: {
         records: new Array(2).fill({
           id: expect.stringMatching(RECORD_ID_REGEX),
-          ronin: {
-            createdAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-            createdBy: null,
-            updatedAt: expect.stringMatching(RECORD_TIMESTAMP_REGEX),
-            updatedBy: null,
-          },
         }),
         modelFields: expect.objectContaining({
           id: 'string',


### PR DESCRIPTION
This change ensures that providing model-specific instructions for a query that affects all models (such as `get.all()`) works correctly, by ensuring that fields are selected as desired.