### PR TITLE
Improve `ResultRecord` type readability

### DIFF
--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -5,15 +5,17 @@ export type ObjectRow = Record<string, unknown>;
 
 export type Row = RawRow | ObjectRow;
 
-export type ResultRecord = Record<string, unknown> & {
+export type ResultRecordBase<T extends Date | string = string> = {
   id: string;
   ronin: {
-    createdAt: string;
+    createdAt: T;
     createdBy: string | null;
-    updatedAt: string;
+    updatedAt: T;
     updatedBy: string | null;
   };
 };
+
+export type ResultRecord = Record<string, unknown> & ResultRecordBase;
 
 export type SingleRecordResult<T = ResultRecord> = {
   record: T | null;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -6,11 +6,27 @@ export type ObjectRow = Record<string, unknown>;
 export type Row = RawRow | ObjectRow;
 
 export type ResultRecordBase<T extends Date | string = string> = {
+  /**
+   * The unique identifier of the record.
+   */
   id: string;
+
   ronin: {
+    /**
+     * The timestamp of when the record was created.
+     */
     createdAt: T;
+    /**
+     * The ID of the user who created the record.
+     */
     createdBy: string | null;
+    /**
+     * The timestamp of the last time the record was updated.
+     */
     updatedAt: T;
+    /**
+     * The ID of the user who last updated the record.
+     */
     updatedBy: string | null;
   };
 };


### PR DESCRIPTION
This change splits out the `ResultRecord` type into a "base type" and the actual type to be used as a result.

Additionally all properties have been updated to add some basic documentation comments.