### PR TITLE
Added `ResultRecordBase` type to root export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -570,6 +570,7 @@ export type {
   RegularResult,
   ExpandedResult,
   ResultRecord,
+  ResultRecordBase,
 } from '@/src/types/result';
 
 // Strip any properties from the root model that are internal


### PR DESCRIPTION
This change fixes a small oversight as part of #162 where the new `ResultRecordBase` type was not actually exported from the package.