### PR TITLE
Correctly store model entity slug

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1098,7 +1098,7 @@ export const transformMetaQuery = (
       // Add the newly created entity to the model.
       if (!existingModel[pluralType]) existingModel[pluralType] = {};
       (existingModel[pluralType] as ModelEntityList<ModelEntity>)[slug] =
-        jsonValue as ModelEntity;
+        entityValue as ModelEntity;
 
       break;
     }

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -651,6 +651,9 @@ test('create new field', async () => {
     },
   ]);
 
+  // Assert that the internally stored models were updated correctly.
+  expect(transaction.models[1].fields).toHaveProperty('email', finalField);
+
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -651,7 +651,7 @@ test('create new field', async () => {
     },
   ]);
 
-  // Assert that the internally stored models were updated correctly.
+  // Assert that the models within the transaction (in memory) were updated correctly.
   expect(transaction.models[1].fields).toHaveProperty('email', finalField);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);


### PR DESCRIPTION
This change ensures that the `slug` attribute of model entities (fields, indexes, etc.) is never stored as part of the attributes of the model entity within the model.

In other words, it prevents a scenario like this one from occurring:

```
fields: {
  test: { slug: test, ... }
}
```