### PR TITLE
Accept objects as JSON default values

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -285,10 +285,10 @@ export const ROOT_MODEL: PartialModel = {
     // Providing an empty object as a default value allows us to use `json_insert`
     // without needing to fall back to an empty object in the insertion statement,
     // which makes the statement shorter.
-    fields: { type: 'json', defaultValue: '{}' },
-    indexes: { type: 'json', defaultValue: '{}' },
-    triggers: { type: 'json', defaultValue: '{}' },
-    presets: { type: 'json', defaultValue: '{}' },
+    fields: { type: 'json', defaultValue: {} },
+    indexes: { type: 'json', defaultValue: {} },
+    triggers: { type: 'json', defaultValue: {} },
+    presets: { type: 'json', defaultValue: {} },
   },
 };
 
@@ -397,6 +397,7 @@ const getFieldStatement = (
         ? `'${field.defaultValue}'`
         : field.defaultValue;
     if (symbol) value = `(${parseFieldExpression(model, 'to', symbol.value as string)})`;
+    if (field.type === 'json') value = `'${JSON.stringify(field.defaultValue)}'`;
 
     statement += ` DEFAULT ${value}`;
   }

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -929,6 +929,48 @@ test('get single record with json field (empty)', async () => {
   expect(result.record).toHaveProperty('someEmptyField', null);
 });
 
+test('get single record with json field (default value)', async () => {
+  const queries: Array<Query> = [
+    {
+      get: {
+        team: null,
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'team',
+      fields: {
+        // We're purposefully using a field that does not exist in the fixtures.
+        someSpecialField: {
+          type: 'json',
+          defaultValue: {
+            special: 'value',
+          },
+        },
+      },
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `SELECT "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "someSpecialField" FROM "teams" LIMIT 1`,
+      params: [],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toHaveProperty('someSpecialField', {
+    special: 'value',
+  });
+});
+
 test('get single record with blob field', async () => {
   const queries: Array<Query> = [
     {

--- a/tests/instructions/with.test.ts
+++ b/tests/instructions/with.test.ts
@@ -929,6 +929,7 @@ test('get single record with json field (empty)', async () => {
   expect(result.record).toHaveProperty('someEmptyField', null);
 });
 
+// Assert that default values of JSON fields are being formatted correctly.
 test('get single record with json field (default value)', async () => {
   const queries: Array<Query> = [
     {

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -752,6 +752,7 @@ test('create new field with many-cardinality relationship', () => {
   ]);
 });
 
+// Assert that objects are being accepted as default values of JSON fields.
 test('create new field with default value (json)', async () => {
   const field: ModelField = {
     type: 'json',

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -652,14 +652,14 @@ test('create new field', async () => {
   ]);
 
   // Assert that the models within the transaction (in memory) were updated correctly.
-  expect(transaction.models[1].fields).toHaveProperty('email', finalField);
+  expect(transaction.models[1].fields).toHaveProperty(field.slug, finalField);
 
   const rawResults = await queryEphemeralDatabase(models, transaction.statements);
   const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
 
   expect(result.record).toHaveProperty('fields', {
     ...getSystemFields('acc'),
-    email: finalField,
+    [field.slug]: finalField,
   });
 });
 
@@ -750,6 +750,60 @@ test('create new field with many-cardinality relationship', () => {
       returning: true,
     },
   ]);
+});
+
+test('create new field with default value (json)', async () => {
+  const field: ModelField = {
+    type: 'json',
+    slug: 'settings',
+    defaultValue: {
+      theme: 'light',
+    },
+  };
+
+  const queries: Array<Query> = [
+    {
+      alter: {
+        model: 'account',
+        create: {
+          field,
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  const finalField = { ...omit(field, ['slug']), name: 'Settings' };
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `ALTER TABLE "accounts" ADD COLUMN "settings" TEXT DEFAULT '{"theme":"light"}'`,
+      params: [],
+    },
+    {
+      statement: `UPDATE "ronin_schema" SET "fields" = json_insert("fields", '$.settings', json(?1)), "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "slug" = ?2 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "name", "pluralName", "slug", "pluralSlug", "idPrefix", "table", "identifiers.name", "identifiers.slug", "fields", "indexes", "triggers", "presets"`,
+      params: [JSON.stringify(finalField), 'account'],
+      returning: true,
+    },
+  ]);
+
+  // Assert that the models within the transaction (in memory) were updated correctly.
+  expect(transaction.models[1].fields).toHaveProperty(field.slug, finalField);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record).toHaveProperty('fields', {
+    ...getSystemFields('acc'),
+    [field.slug]: finalField,
+  });
 });
 
 // Ensure that, if the `slug` of a field changes during a model update, an `ALTER TABLE`


### PR DESCRIPTION
This change ensures that providing an object as a default value for a JSON field (instead of a string) works just fine!