### PR TITLE
Expose `list` query type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -574,6 +574,7 @@ export type {
   CountQuery,
   CountInstructions,
   CountInstructions as CountQueryInstructions,
+  ListQuery,
   CreateQuery,
   AlterQuery,
   DropQuery,


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/compiler/pull/168 and ensures that the TypeScript types for the `list` query type are being exported.