### PR TITLE
Don't duplicate fields from `selecting` and `using`

### DIFF
--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -41,7 +41,6 @@ export const handleSelecting = (
     including: Instructions['including'];
     orderedBy: Instructions['orderedBy'];
     limitedTo: Instructions['limitedTo'];
-    using: Instructions['using'];
   },
   options: {
     /** The path on which the selected fields should be mounted in the final record. */

--- a/src/instructions/selecting.ts
+++ b/src/instructions/selecting.ts
@@ -41,6 +41,7 @@ export const handleSelecting = (
     including: Instructions['including'];
     orderedBy: Instructions['orderedBy'];
     limitedTo: Instructions['limitedTo'];
+    using: Instructions['using'];
   },
   options: {
     /** The path on which the selected fields should be mounted in the final record. */

--- a/src/instructions/using.ts
+++ b/src/instructions/using.ts
@@ -71,10 +71,12 @@ export const handleUsing = (
         let newValue: unknown;
 
         if (Array.isArray(currentValue)) {
-          newValue = [
-            ...(replacedUsingFilter[instructionName] as Array<unknown>),
-            ...(currentValue as Array<unknown>),
-          ];
+          newValue = Array.from(
+            new Set([
+              ...(replacedUsingFilter[instructionName] as Array<unknown>),
+              ...(currentValue as Array<unknown>),
+            ]),
+          );
         } else if (isObject(currentValue)) {
           newValue = {
             ...(replacedUsingFilter[instructionName] as object),


### PR DESCRIPTION
When executing a `get` query that includes both `selecting` and `using` clauses with identical fields, the generated SQL statement incorrectly attempts to query these fields twice. 
This results in a SQL statement such as `SELECT id, name, id, name ...`.

