### PR TITLE
Allow empty value for JSON and Blob fields

### DIFF
--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -340,7 +340,7 @@ export const composeConditions = (
         isObject(value) || (modelField?.type === 'blob' ? null : Array.isArray(value));
 
       if (!valueIsJSON || getQuerySymbol(value) || fieldIsJSON) {
-        if (modelField && fieldIsJSON && !valueIsJSON) {
+        if (modelField && fieldIsJSON && !valueIsJSON && value !== null) {
           const messagePrefix = 'The provided field value is not';
           const message =
             modelField.type === 'json'

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -162,6 +162,52 @@ test('set single record to new blob field with invalid value', () => {
   expect(error).toHaveProperty('field', 'avatar');
 });
 
+test('set single record to new blob field with empty value', async () => {
+  const queries: Array<Query> = [
+    {
+      set: {
+        account: {
+          with: {
+            handle: 'elaine',
+          },
+          to: {
+            avatar: null,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+      fields: {
+        handle: {
+          type: 'string',
+        },
+        avatar: {
+          type: 'blob',
+        },
+      },
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `UPDATE "accounts" SET "avatar" = NULL, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "handle" = ?1 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "avatar"`,
+      params: ['elaine'],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record?.avatar).toBeNull();
+});
+
 test('set single record to new string field with expression referencing fields', async () => {
   const queries: Array<Query> = [
     {
@@ -644,6 +690,52 @@ test('set single record to new json field with invalid value', () => {
   );
   expect(error).toHaveProperty('code', 'INVALID_FIELD_VALUE');
   expect(error).toHaveProperty('field', 'emails');
+});
+
+test('set single record to new json field with empty value', async () => {
+  const queries: Array<Query> = [
+    {
+      set: {
+        account: {
+          with: {
+            handle: 'elaine',
+          },
+          to: {
+            emails: null,
+          },
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+      fields: {
+        handle: {
+          type: 'string',
+        },
+        emails: {
+          type: 'json',
+        },
+      },
+    },
+  ];
+
+  const transaction = new Transaction(queries, { models });
+
+  expect(transaction.statements).toEqual([
+    {
+      statement: `UPDATE "accounts" SET "emails" = NULL, "ronin.updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', 'now') || 'Z' WHERE "handle" = ?1 RETURNING "id", "ronin.createdAt", "ronin.createdBy", "ronin.updatedAt", "ronin.updatedBy", "handle", "emails"`,
+      params: ['elaine'],
+      returning: true,
+    },
+  ]);
+
+  const rawResults = await queryEphemeralDatabase(models, transaction.statements);
+  const result = transaction.formatResults(rawResults)[0] as SingleRecordResult;
+
+  expect(result.record?.emails).toBeNull();
 });
 
 test('set single record to new nested string field', async () => {


### PR DESCRIPTION
This change ensures that empty values are accepted for JSON and Blob fields.