### PR TITLE
Use correct peer dependency versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "typescript": "5.7.2",
       },
       "peerDependencies": {
-        "@ronin/engine": "0.0.27",
+        "@ronin/engine": ">=0.1.23",
       },
     },
   },
@@ -138,7 +138,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.41.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw=="],
 
-    "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
+    "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
     "@types/bun": ["@types/bun@1.1.14", "", { "dependencies": { "bun-types": "1.1.37" } }, "sha512-opVYiFGtO2af0dnWBdZWlioLBoxSdDO5qokaazLhq8XQtGZbY4pY3/JxY8Zdf/hEwGubbp7ErZXoN1+h2yesxA=="],
 
@@ -326,7 +326,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+    "zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript": "5.7.2"
   },
   "peerDependencies": {
-    "@ronin/engine": "0.0.27"
+    "@ronin/engine": ">=0.1.23"
   }
 }

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,10 +1,10 @@
 import fixtureData from '@/fixtures/data.json';
 import { type Model, type Query, ROOT_MODEL, Transaction } from '@/src/index';
 import { convertToSnakeCase, getProperty, setProperty } from '@/src/utils/helpers';
-import { type Database, Engine } from '@ronin/engine';
+import { Engine } from '@ronin/engine';
 import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
-import type { Row, Statement } from '@ronin/engine/types';
+import type { Database, Row, Statement } from '@ronin/engine/resources';
 
 /** A regex for asserting RONIN record IDs. */
 export const RECORD_ID_REGEX = /[a-z]{3}_[a-z0-9]{16}/;
@@ -72,8 +72,8 @@ const prefillDatabase = async (
 };
 
 const ENGINE = new Engine({
-  resolvers: [(engine) => new MemoryResolver(engine)],
-  driver: new BunDriver(),
+  driver: (engine): BunDriver => new BunDriver({ engine }),
+  resolvers: [(engine) => new MemoryResolver({ engine })],
 });
 
 /**


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/compiler/pull/177 and ensures the correct versions of peer dependencies.