### PR TITLE
Split query types into read and write

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -608,6 +608,8 @@ export { RoninError, getQuerySymbol } from '@/src/utils/helpers';
 export {
   QUERY_SYMBOLS,
   QUERY_TYPES,
+  QUERY_TYPES_READ,
+  QUERY_TYPES_WRITE,
   DML_QUERY_TYPES,
   DML_QUERY_TYPES_READ,
   DML_QUERY_TYPES_WRITE,

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,4 +612,6 @@ export {
   DML_QUERY_TYPES_READ,
   DML_QUERY_TYPES_WRITE,
   DDL_QUERY_TYPES,
+  DDL_QUERY_TYPES_READ,
+  DDL_QUERY_TYPES_WRITE,
 } from '@/src/utils/constants';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -22,6 +22,18 @@ export const DDL_QUERY_TYPES = [
   ...DDL_QUERY_TYPES_WRITE,
 ] as const;
 
+/** All read query types. */
+export const QUERY_TYPES_READ = [
+  ...DML_QUERY_TYPES_READ,
+  ...DDL_QUERY_TYPES_READ,
+] as const;
+
+/** All write query types. */
+export const QUERY_TYPES_WRITE = [
+  ...DML_QUERY_TYPES_WRITE,
+  ...DDL_QUERY_TYPES_WRITE,
+] as const;
+
 /** All query types. */
 export const QUERY_TYPES = [...DML_QUERY_TYPES, ...DDL_QUERY_TYPES] as const;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,8 +10,17 @@ export const DML_QUERY_TYPES = [
   ...DML_QUERY_TYPES_WRITE,
 ] as const;
 
+/** Query types used for reading the database schema. */
+export const DDL_QUERY_TYPES_READ = ['list'] as const;
+
+/** Query types used for writing the database schema. */
+export const DDL_QUERY_TYPES_WRITE = ['create', 'alter', 'drop'] as const;
+
 /** Query types used for interacting with the database schema. */
-export const DDL_QUERY_TYPES = ['list', 'create', 'alter', 'drop'] as const;
+export const DDL_QUERY_TYPES = [
+  ...DDL_QUERY_TYPES_READ,
+  ...DDL_QUERY_TYPES_WRITE,
+] as const;
 
 /** All query types. */
 export const QUERY_TYPES = [...DML_QUERY_TYPES, ...DDL_QUERY_TYPES] as const;


### PR DESCRIPTION
This change ensures the following exports:

```typescript
QUERY_TYPES
QUERY_TYPES_READ
QUERY_TYPES_WRITE

DML_QUERY_TYPES
DML_QUERY_TYPES_READ
DML_QUERY_TYPES_WRITE

DDL_QUERY_TYPES
DDL_QUERY_TYPES_READ
DDL_QUERY_TYPES_WRITE
```

Before the change, only the following exports were present:

```typescript
QUERY_TYPES

DML_QUERY_TYPES
DML_QUERY_TYPES_READ
DML_QUERY_TYPES_WRITE

DDL_QUERY_TYPES
```