### PR TITLE
Provide helpful name for compiler errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -602,7 +602,7 @@ const CLEAN_ROOT_MODEL = omit(ROOT_MODEL, ['system']) as PublicModel;
 export { Transaction, CLEAN_ROOT_MODEL as ROOT_MODEL };
 
 // Expose the main error class and helper functions
-export { RoninError, getQuerySymbol } from '@/src/utils/helpers';
+export { CompilerError, getQuerySymbol } from '@/src/utils/helpers';
 
 // Expose constants
 export {

--- a/src/instructions/before-after.ts
+++ b/src/instructions/before-after.ts
@@ -1,7 +1,7 @@
 import { getFieldFromModel } from '@/src/model';
 import type { Model } from '@/src/types/model';
 import type { GetInstructions, QueryType } from '@/src/types/query';
-import { RoninError } from '@/src/utils/helpers';
+import { CompilerError } from '@/src/utils/helpers';
 import { CURSOR_NULL_PLACEHOLDER, CURSOR_SEPARATOR } from '@/src/utils/pagination';
 import { prepareStatementValue } from '@/src/utils/statement';
 
@@ -34,14 +34,14 @@ export const handleBeforeOrAfter = (
   },
 ): string => {
   if (!(instructions.before || instructions.after)) {
-    throw new RoninError({
+    throw new CompilerError({
       message: 'The `before` or `after` instruction must not be empty.',
       code: 'MISSING_INSTRUCTION',
     });
   }
 
   if (instructions.before && instructions.after) {
-    throw new RoninError({
+    throw new CompilerError({
       message: 'The `before` and `after` instructions cannot co-exist. Choose one.',
       code: 'MUTUALLY_EXCLUSIVE_INSTRUCTIONS',
     });
@@ -52,7 +52,7 @@ export const handleBeforeOrAfter = (
     message += ' instruction, a `limitedTo` instruction must be provided as well, to';
     message += ' define the page size.';
 
-    throw new RoninError({
+    throw new CompilerError({
       message,
       code: 'MISSING_INSTRUCTION',
     });

--- a/src/instructions/using.ts
+++ b/src/instructions/using.ts
@@ -1,7 +1,7 @@
 import type { Model, ModelField, ModelPreset } from '@/src/types/model';
 import type { Instructions, SetInstructions } from '@/src/types/query';
 import { QUERY_SYMBOLS } from '@/src/utils/constants';
-import { RoninError, findInObject, isObject } from '@/src/utils/helpers';
+import { CompilerError, findInObject, isObject } from '@/src/utils/helpers';
 
 /**
  * Generates the SQL syntax for the `using` query instruction, which allows for quickly
@@ -41,7 +41,7 @@ export const handleUsing = (
     const preset = model.presets?.[presetSlug];
 
     if (!preset) {
-      throw new RoninError({
+      throw new CompilerError({
         message: `Preset "${presetSlug}" does not exist in model "${model.name}".`,
         code: 'PRESET_NOT_FOUND',
       });

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -28,8 +28,8 @@ import {
   QUERY_SYMBOLS,
 } from '@/src/utils/constants';
 import {
+  CompilerError,
   MODEL_ENTITY_ERROR_CODES,
-  RoninError,
   convertToCamelCase,
   convertToSnakeCase,
   getQuerySymbol,
@@ -56,7 +56,7 @@ export const getModelBySlug = <T extends Model | PublicModel>(
   });
 
   if (!model) {
-    throw new RoninError({
+    throw new CompilerError({
       message: `No matching model with either Slug or Plural Slug of "${slug}" could be found.`,
       code: 'MODEL_NOT_FOUND',
     });
@@ -199,7 +199,7 @@ export function getFieldFromModel(
 
   if (!modelField) {
     if (shouldThrow) {
-      throw new RoninError({
+      throw new CompilerError({
         message: `${errorPrefix} does not exist in model "${model.name}".`,
         code: 'FIELD_NOT_FOUND',
         field: fieldPath,
@@ -410,7 +410,7 @@ const getFieldStatement = (
     if (symbol) value = `(${parseFieldExpression(model, 'to', symbol.value as string)})`;
     if (field.type === 'json') {
       if (!isObject(field.defaultValue)) {
-        throw new RoninError({
+        throw new CompilerError({
           message: `The default value of JSON field "${field.slug}" must be an object.`,
           code: 'INVALID_MODEL_VALUE',
           field: 'fields',
@@ -896,14 +896,14 @@ export const transformMetaQuery = (
 
   // Throw an error if the entity that was targeted is not available in the model.
   if ((action === 'alter' || action === 'drop') && !existingEntity) {
-    throw new RoninError({
+    throw new CompilerError({
       message: `No ${entity} with slug "${slug}" defined in model "${existingModel.name}".`,
       code: MODEL_ENTITY_ERROR_CODES[entity],
     });
   }
 
   if (action === 'create' && existingEntity) {
-    throw new RoninError({
+    throw new CompilerError({
       message: `A ${entity} with the slug "${slug}" already exists.`,
       code: 'EXISTING_MODEL_ENTITY',
       fields: ['slug'],
@@ -959,7 +959,7 @@ export const transformMetaQuery = (
       const isSystemField = slug in systemFields;
 
       if (isSystemField) {
-        throw new RoninError({
+        throw new CompilerError({
           message: `The ${entity} "${slug}" is a system ${entity} and cannot be removed.`,
           code: 'REQUIRED_MODEL_ENTITY',
         });
@@ -982,7 +982,7 @@ export const transformMetaQuery = (
 
     if (action === 'create') {
       if (!Array.isArray(index.fields) || index.fields.length === 0) {
-        throw new RoninError({
+        throw new CompilerError({
           message: `When ${actionReadable} ${PLURAL_MODEL_ENTITIES[entity]}, at least one field must be provided.`,
           code: 'INVALID_MODEL_VALUE',
           field: PLURAL_MODEL_ENTITIES[entity],

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -32,7 +32,7 @@ export const composeMountingPath = (
   return `${mountingPath ? `${mountingPath}.` : ''}${single ? key : `${key}[0]`}`;
 };
 
-type RoninErrorCode =
+type CompilerErrorCode =
   | 'MODEL_NOT_FOUND'
   | 'FIELD_NOT_FOUND'
   | 'INDEX_NOT_FOUND'
@@ -64,14 +64,14 @@ interface Issue {
 
 interface Details {
   message: string;
-  code: RoninErrorCode;
+  code: CompilerErrorCode;
   field?: string;
   fields?: Array<string>;
   issues?: Array<Issue>;
   queries?: Array<Query> | null;
 }
 
-export class RoninError extends Error {
+export class CompilerError extends Error {
   code: Details['code'];
   field?: Details['field'];
   fields?: Details['fields'];
@@ -81,7 +81,7 @@ export class RoninError extends Error {
   constructor(details: Details) {
     super(details.message);
 
-    this.name = 'RoninError';
+    this.name = 'CompilerError';
     this.code = details.code;
     this.field = details.field;
     this.fields = details.fields;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ import type {
   Statement,
 } from '@/src/types/query';
 import { DML_QUERY_TYPES_WRITE, QUERY_SYMBOLS } from '@/src/utils/constants';
-import { RoninError, isObject, splitQuery } from '@/src/utils/helpers';
+import { CompilerError, isObject, splitQuery } from '@/src/utils/helpers';
 import { formatIdentifiers } from '@/src/utils/statement';
 
 /**
@@ -236,7 +236,7 @@ export const compileQueryInput = (
       !(instructionValue && isObject(instructionValue)) ||
       Object.keys(instructionValue).length === 0
     ) {
-      throw new RoninError({
+      throw new CompilerError({
         message: `When using a \`${queryType}\` query, the \`${instructionName}\` instruction must be a non-empty object.`,
         code: instructionName === 'to' ? 'INVALID_TO_VALUE' : 'INVALID_WITH_VALUE',
         queries: [query],
@@ -278,7 +278,7 @@ export const compileQueryInput = (
       typeof instructions.after !== 'undefined')
   ) {
     if (single) {
-      throw new RoninError({
+      throw new CompilerError({
         message:
           'The `before` and `after` instructions are not supported when querying for a single record.',
         code: 'INVALID_BEFORE_OR_AFTER_INSTRUCTION',

--- a/src/utils/statement.ts
+++ b/src/utils/statement.ts
@@ -19,7 +19,7 @@ import type {
   WithInstruction,
 } from '@/src/types/query';
 import { QUERY_SYMBOLS, RONIN_MODEL_FIELD_REGEX } from '@/src/utils/constants';
-import { RoninError, getQuerySymbol, isObject } from '@/src/utils/helpers';
+import { CompilerError, getQuerySymbol, isObject } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
 
 /**
@@ -347,7 +347,7 @@ export const composeConditions = (
               ? `${messagePrefix} valid JSON. Only objects and arrays should be provided. Other types of values should be stored in their respective primitive field types.`
               : `${messagePrefix} a valid Blob reference.`;
 
-          throw new RoninError({
+          throw new CompilerError({
             message,
             field: modelField?.slug,
             code: 'INVALID_FIELD_VALUE',
@@ -460,7 +460,7 @@ export const composeConditions = (
   // If the provided value could not be matched against any of the allowed value types,
   // that means the provided value is empty, which is not allowed. To inform the
   // developer, we are therefore throwing an error.
-  throw new RoninError({
+  throw new CompilerError({
     message: `The \`with\` instruction must not contain an empty field. The following fields are empty: \`${options.fieldSlug}\`. If you meant to query by an empty field, try using \`null\` instead.`,
     code: 'INVALID_WITH_VALUE',
     queries: null,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { type Model, type Query, RoninError, Transaction } from '@/src/index';
+import { CompilerError, type Model, type Query, Transaction } from '@/src/index';
 
 test('get single record with non-existing field', () => {
   const queries: Array<Query> = [
@@ -28,7 +28,7 @@ test('get single record with non-existing field', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'Field "handle" defined for `with` does not exist in model "Account".',
@@ -59,7 +59,7 @@ test('get single record with non-existing model', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'No matching model with either Slug or Plural Slug of "account" could be found.',
@@ -99,7 +99,7 @@ test('get single record with empty `with` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The `with` instruction must not contain an empty field. The following fields are empty: `handle`. If you meant to query by an empty field, try using `null` instead.',
@@ -135,7 +135,7 @@ test('set single record with empty `to` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'When using a `set` query, the `to` instruction must be a non-empty object.',
@@ -168,7 +168,7 @@ test('add single record with empty `with` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'When using a `add` query, the `with` instruction must be a non-empty object.',
@@ -201,7 +201,7 @@ test('get single record with `before` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The `before` and `after` instructions are not supported when querying for a single record.',
@@ -234,7 +234,7 @@ test('get single record with `after` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The `before` and `after` instructions are not supported when querying for a single record.',
@@ -268,7 +268,7 @@ test('get multiple records with `before` and `after` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The `before` and `after` instructions cannot co-exist. Choose one.',
@@ -301,7 +301,7 @@ test('get multiple records with empty `before` instruction', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The `before` or `after` instruction must not be empty.',

--- a/tests/instructions/before-after.test.ts
+++ b/tests/instructions/before-after.test.ts
@@ -4,7 +4,7 @@ import {
   RECORD_TIMESTAMP_REGEX,
   queryEphemeralDatabase,
 } from '@/fixtures/utils';
-import { type Model, type Query, RoninError, Transaction } from '@/src/index';
+import { CompilerError, type Model, type Query, Transaction } from '@/src/index';
 import type {
   AmountResult,
   MultipleRecordResult,
@@ -864,7 +864,7 @@ test('get multiple records before cursor without limit', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'When providing a pagination cursor in the `before` or `after` instruction, a `limitedTo` instruction must be provided as well, to define the page size.',

--- a/tests/instructions/to.test.ts
+++ b/tests/instructions/to.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
 import {
+  CompilerError,
   type Model,
   QUERY_SYMBOLS,
   type Query,
-  RoninError,
   type StoredObject,
   Transaction,
 } from '@/src/index';
@@ -153,7 +153,7 @@ test('set single record to new blob field with invalid value', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The provided field value is not a valid Blob reference.',
@@ -683,7 +683,7 @@ test('set single record to new json field with invalid value', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The provided field value is not valid JSON. Only objects and arrays should be provided. Other types of values should be stored in their respective primitive field types.',
@@ -1308,7 +1308,7 @@ test('try to add multiple records with nested sub query including non-existent f
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'Field "nonExistingField" defined for `to` does not exist in model "New Account".',

--- a/tests/instructions/using.test.ts
+++ b/tests/instructions/using.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
 import {
+  CompilerError,
   type Model,
   QUERY_SYMBOLS,
   type Query,
-  RoninError,
   Transaction,
 } from '@/src/index';
 
@@ -915,7 +915,7 @@ test('try get single record with non-existing preset', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'Preset "activeMember" does not exist in model "Account".',

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import {
+  CompilerError,
   type Model,
   type ModelField,
   type ModelIndex,
@@ -7,7 +8,6 @@ import {
   QUERY_SYMBOLS,
   type Query,
   ROOT_MODEL,
-  RoninError,
   Transaction,
 } from '@/src/index';
 
@@ -642,7 +642,7 @@ test('query a model that was just dropped', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'No matching model with either Slug or Plural Slug of "account" could be found.',
@@ -878,7 +878,7 @@ test('create new field with default value (invalid json)', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The default value of JSON field "settings" must be an object.',
@@ -1636,7 +1636,7 @@ test('try to alter existing model that does not exist', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'No matching model with either Slug or Plural Slug of "account" could be found.',
@@ -1670,7 +1670,7 @@ test('try to alter existing model entity that does not exist', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'No field with slug "email" defined in model "Account".',
@@ -1706,7 +1706,7 @@ test('try to create new entity with slug of existing entity', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty('message', 'A field with the slug "id" already exists.');
   expect(error).toHaveProperty('code', 'EXISTING_MODEL_ENTITY');
 });
@@ -1737,7 +1737,7 @@ test('try to drop a system field', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'The field "id" is a system field and cannot be removed.',
@@ -1776,7 +1776,7 @@ test('try to create new index without fields', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'When creating indexes, at least one field must be provided.',
@@ -1819,7 +1819,7 @@ test('try to create new index with non-existent field', () => {
     error = err as Error;
   }
 
-  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toBeInstanceOf(CompilerError);
   expect(error).toHaveProperty(
     'message',
     'Field "handle" defined for index "index_slug" does not exist in model "Account".',


### PR DESCRIPTION
The name "RoninError" is pretty meaningless, since it might stem from any component of the RONIN platform.

With the name "CompilerError", it becomes clear that the error stems from the compiler.